### PR TITLE
Adds the Access-Control-Expose-Headers header

### DIFF
--- a/msgraph-developer-proxy/ChaosEngine.cs
+++ b/msgraph-developer-proxy/ChaosEngine.cs
@@ -339,6 +339,7 @@ namespace Microsoft.Graph.DeveloperProxy {
 
             if (e.HttpClient.Request.Headers.FirstOrDefault((HttpHeader h) => h.Name.Equals("Origin", StringComparison.OrdinalIgnoreCase)) is not null) {
                 responseComponents.Headers.Add(new HttpHeader("Access-Control-Allow-Origin", "*"));
+                responseComponents.Headers.Add(new HttpHeader("Access-Control-Expose-Headers", "ETag, Location, Preference-Applied, Content-Range, request-id, client-request-id, ReadWriteConsistencyToken, SdkVersion, WWW-Authenticate, x-ms-client-gcc-tenant, Retry-After"));
             }
 
             if ((int)responseComponents.ErrorStatus >= 400 && string.IsNullOrEmpty(responseComponents.Body)) {


### PR DESCRIPTION
Adds the Access-Control-Expose-Headers header which is required for client-side apps to be able to access the retry-after header and properly back-off when throttled.