### PR TITLE
Timeout parameter option

### DIFF
--- a/dev-proxy-abstractions/IInactivityTimer.cs
+++ b/dev-proxy-abstractions/IInactivityTimer.cs
@@ -1,0 +1,8 @@
+namespace DevProxy.Abstractions
+{
+    public interface IInactivityTimer
+    {
+        void Reset();
+        void Stop();
+    }
+}

--- a/dev-proxy-abstractions/IProxyConfiguration.cs
+++ b/dev-proxy-abstractions/IProxyConfiguration.cs
@@ -21,4 +21,5 @@ public interface IProxyConfiguration
     IEnumerable<int> WatchPids { get; }
     IEnumerable<string> WatchProcessNames { get; }
     bool ShowTimestamps { get; }
+    long? Timeout { get; }
 }

--- a/dev-proxy/CommandHandlers/ProxyCommandHandler.cs
+++ b/dev-proxy/CommandHandlers/ProxyCommandHandler.cs
@@ -135,6 +135,11 @@ public class ProxyCommandHandler(IPluginEvents pluginEvents,
         {
             Configuration.InstallCert = installCert.Value;
         }
+        var timeout = context.ParseResult.GetValueForOption<long?>(ProxyHost.TimeoutOptionName, _options);
+        if (timeout is not null)
+        {
+            Configuration.Timeout = timeout.Value;
+        }
     }
 
     private async Task CheckForNewVersionAsync()

--- a/dev-proxy/InactivityTimer.cs
+++ b/dev-proxy/InactivityTimer.cs
@@ -1,0 +1,30 @@
+using DevProxy.Abstractions;
+
+namespace DevProxy
+{
+    public class InactivityTimer : IInactivityTimer
+    {
+        private Timer? _timer;
+        private readonly TimeSpan _timeout;
+        private static readonly TimeSpan InfiniteTimeout = TimeSpan.FromMilliseconds(-1);
+
+        public InactivityTimer(long timeoutSeconds, Action timeoutAction)
+        {
+            _timeout = TimeSpan.FromSeconds(timeoutSeconds);
+            Action action = timeoutAction ?? throw new ArgumentNullException(nameof(timeoutAction));
+        
+            _timer = new Timer(_ => action.Invoke(), null, _timeout, InfiniteTimeout);
+        }
+
+        public void Reset()
+        {
+            this._timer?.Change(_timeout, InfiniteTimeout);
+        }
+
+        public void Stop()
+        {
+            this._timer?.Dispose();
+            _timer = null;
+        }
+    }
+}

--- a/dev-proxy/Properties/launchSettings.json
+++ b/dev-proxy/Properties/launchSettings.json
@@ -45,6 +45,10 @@
     "Jwt create": {
       "commandName": "Project",
       "commandLineArgs": "jwt create"
+    },
+    "Timeout": {
+      "commandName": "Project",
+      "commandLineArgs": "--timeout 30"
     }
   }
 }

--- a/dev-proxy/ProxyConfiguration.cs
+++ b/dev-proxy/ProxyConfiguration.cs
@@ -39,5 +39,5 @@ public class ProxyConfiguration : IProxyConfiguration
     public int ApiPort { get; set; } = 8897;
     public bool ShowSkipMessages { get; set; } = true;
     public bool ShowTimestamps { get; set; } = true;
-    public long? Timeout { get; set; } = 60000;
+    public long? Timeout { get; set; }
 }

--- a/dev-proxy/ProxyConfiguration.cs
+++ b/dev-proxy/ProxyConfiguration.cs
@@ -39,4 +39,5 @@ public class ProxyConfiguration : IProxyConfiguration
     public int ApiPort { get; set; } = 8897;
     public bool ShowSkipMessages { get; set; } = true;
     public bool ShowTimestamps { get; set; } = true;
+    public long? Timeout { get; set; } = 60000;
 }

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -348,6 +348,8 @@ public class ProxyEngine(IProxyConfiguration config, ISet<UrlToWatch> urlsToWatc
                 }
             }
 
+            _inactivityTimer?.Stop();
+
             if (RunTime.IsMac && _config.AsSystemProxy)
             {
                 ToggleSystemProxy(ToggleSystemProxyAction.Off);

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -271,18 +271,25 @@ internal class ProxyHost
         };
         _urlsToWatchOption.AddAlias("-u");
         
-        _timeoutOption = new Option<long?>(TimeoutOptionName, "No request shutdown dev-proxy timeout.");
+        _timeoutOption = new Option<long?>(TimeoutOptionName, "Time in seconds after which the proxy quits, resets when a request is being made")
+        {
+            ArgumentHelpName = "inactivityTimeout",
+        };
         _timeoutOption.AddValidator(input =>
         {
             try
             {
-                _ = input.GetValueForOption(_timeoutOption);
+                if (!long.TryParse(input.Tokens[0].Value, out _))
+                {
+                    input.ErrorMessage = $"{input.Tokens[0].Value} is not of type long";
+                }
             }
             catch (InvalidOperationException ex)
             {
                 input.ErrorMessage = ex.Message;
             }
         });
+        _timeoutOption.AddAlias("-t");
 
         ProxyCommandHandler.Configuration.ConfigFile = ConfigFile;
     }

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -35,6 +35,8 @@ internal class ProxyHost
     private readonly Option<bool?> _installCertOption;
     internal static readonly string UrlsToWatchOptionName = "--urls-to-watch";
     private static Option<IEnumerable<string>?>? _urlsToWatchOption;
+    internal static readonly string TimeoutOptionName = "--timeout";
+    private readonly Option<long?> _timeoutOption;
 
     private static bool _configFileResolved = false;
     private static string _configFile = "devproxyrc.json";
@@ -268,6 +270,19 @@ internal class ProxyHost
             Arity = ArgumentArity.ZeroOrMore
         };
         _urlsToWatchOption.AddAlias("-u");
+        
+        _timeoutOption = new Option<long?>(TimeoutOptionName, "No request shutdown dev-proxy timeout.");
+        _timeoutOption.AddValidator(input =>
+        {
+            try
+            {
+                _ = input.GetValueForOption(_timeoutOption);
+            }
+            catch (InvalidOperationException ex)
+            {
+                input.ErrorMessage = ex.Message;
+            }
+        });
 
         ProxyCommandHandler.Configuration.ConfigFile = ConfigFile;
     }
@@ -291,7 +306,8 @@ internal class ProxyHost
             _installCertOption,
             // _urlsToWatchOption is set while initialize the Program
             // As such, it's always set here
-            _urlsToWatchOption!
+            _urlsToWatchOption!,
+            _timeoutOption
         };
         command.Description = "Dev Proxy is a command line tool for testing Microsoft Graph, SharePoint Online and any other HTTP APIs.";
 
@@ -457,6 +473,7 @@ internal class ProxyHost
             _noFirstRunOption,
             _asSystemProxyOption,
             _installCertOption,
+            _timeoutOption,
             .. optionsFromPlugins,
         ],
         urlsToWatch,

--- a/dev-proxy/ProxyHost.cs
+++ b/dev-proxy/ProxyHost.cs
@@ -281,7 +281,7 @@ internal class ProxyHost
             {
                 if (!long.TryParse(input.Tokens[0].Value, out _))
                 {
-                    input.ErrorMessage = $"{input.Tokens[0].Value} is not of type long";
+                    input.ErrorMessage = $"{input.Tokens[0].Value} is not valid as a timeout value";
                 }
             }
             catch (InvalidOperationException ex)


### PR DESCRIPTION
Adds the parameter "--timeout" which when given configures a timer that closes the proxy after it expires.
The Timer resets to the initial value if a request to the proxy is being made.

It uses the same method to stop the Application as the stopProxy Endpoint

![dev-proxy-commands-j](https://github.com/user-attachments/assets/20cb02c5-2ef6-4e5d-86b8-37b5177dbf81)

Closes #845

Let me know if you have any suggestions :)
