### PR TITLE
Updates Docker images to not use a fixed certificate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,20 +27,21 @@ RUN apt -y update && apt -y upgrade && \
     # Install Dev Proxy
     /bin/bash -c "$(curl -sL https://aka.ms/devproxy/setup.sh)" -- v${DEVPROXY_VERSION} && \
     echo "export PATH=$PATH:$(pwd)/devproxy" >> /home/${USERNAME}/.bashrc && \
-    # Create a directory for the configuration
-    mkdir -p /home/${USERNAME}/.config && \
+    # Create a directory for the configuration & root certificate
+    mkdir -p /home/${USERNAME}/.config/dev-proxy/rootCert && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Prevents error "Couldn't find a valid ICU package" when running Dev Proxy
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
     # Required for .NET to properly resolve SpecialFolder.ApplicationData
-    XDG_DATA_HOME=/home/${USERNAME}/.config
+    XDG_DATA_HOME=/home/${USERNAME}/.config \
+    # Put the root certificate in a sub folder so that it can be mounted
+    DEV_PROXY_CERT_PATH=rootCert/rootCert.pfx
 
+VOLUME /home/${USERNAME}/.config/dev-proxy/rootCert
 VOLUME /config
 WORKDIR /config
 
 USER ${USERNAME}
-
-RUN /app/devproxy/devproxy cert ensure
 
 ENTRYPOINT ["/app/devproxy/devproxy", "--ip-address", "0.0.0.0"]

--- a/Dockerfile_beta
+++ b/Dockerfile_beta
@@ -27,20 +27,21 @@ RUN apt -y update && apt -y upgrade && \
     # Install Dev Proxy
     /bin/bash -c "$(curl -sL https://aka.ms/devproxy/setup-beta.sh)" -- v${DEVPROXY_VERSION} && \
     echo "export PATH=$PATH:$(pwd)/devproxy-beta" >> /home/${USERNAME}/.bashrc && \
-    # Create a directory for the configuration
-    mkdir -p /home/${USERNAME}/.config && \
+    # Create a directory for the configuration & root certificate
+    mkdir -p /home/${USERNAME}/.config/dev-proxy/rootCert && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Prevents error "Couldn't find a valid ICU package" when running Dev Proxy
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
     # Required for .NET to properly resolve SpecialFolder.ApplicationData
-    XDG_DATA_HOME=/home/${USERNAME}/.config
+    XDG_DATA_HOME=/home/${USERNAME}/.config \
+    # Put the root certificate in a sub folder so that it can be mounted
+    DEV_PROXY_CERT_PATH=rootCert/rootCert.pfx
 
+VOLUME /home/${USERNAME}/.config/dev-proxy/rootCert
 VOLUME /config
 WORKDIR /config
 
 USER ${USERNAME}
-
-RUN /app/devproxy-beta/devproxy-beta cert ensure
 
 ENTRYPOINT ["/app/devproxy-beta/devproxy-beta", "--ip-address", "0.0.0.0"]

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -48,6 +48,7 @@ public class ProxyEngine(IProxyConfiguration config, ISet<UrlToWatch> urlsToWatc
     static ProxyEngine()
     {
         _proxyServer = new ProxyServer();
+        _proxyServer.CertificateManager.PfxFilePath = Environment.GetEnvironmentVariable("DEV_PROXY_CERT_PATH") ?? string.Empty;
         _proxyServer.CertificateManager.RootCertificateName = "Dev Proxy CA";
         _proxyServer.CertificateManager.CertificateStorage = new CertificateDiskCache();
         // we need to change this to a value lower than 397

--- a/scripts/Dockerfile_local
+++ b/scripts/Dockerfile_local
@@ -1,6 +1,6 @@
 FROM ubuntu:24.04
 
-ARG DEVPROXY_VERSION=0.26.0-beta.1
+ARG DEVPROXY_VERSION=0.26.0-beta.4
 ARG USERNAME=devproxy
 ENV DEVPROXY_VERSION=${DEVPROXY_VERSION}
 
@@ -27,20 +27,21 @@ RUN apt -y update && apt -y upgrade && \
     # Create a new user
     useradd -ms /bin/bash ${USERNAME} && \
     echo "export PATH=$PATH:$(pwd)/devproxy" >> /home/${USERNAME}/.bashrc && \
-    # Create a directory for the configuration
-    mkdir -p /home/${USERNAME}/.config && \
+    # Create a directory for the configuration & root certificate
+    mkdir -p /home/${USERNAME}/.config/dev-proxy/rootCert && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Prevents error "Couldn't find a valid ICU package" when running Dev Proxy
 ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1 \
     # Required for .NET to properly resolve SpecialFolder.ApplicationData
-    XDG_DATA_HOME=/home/${USERNAME}/.config
+    XDG_DATA_HOME=/home/${USERNAME}/.config \
+    # Put the root certificate in a sub folder so that it can be mounted
+    DEV_PROXY_CERT_PATH=rootCert/rootCert.pfx
 
+VOLUME /home/${USERNAME}/.config/dev-proxy/rootCert
 VOLUME /config
 WORKDIR /config
 
 USER ${USERNAME}
-
-RUN /app/devproxy/devproxy cert ensure
 
 ENTRYPOINT ["/app/devproxy/devproxy", "--ip-address", "0.0.0.0"]

--- a/scripts/version.ps1
+++ b/scripts/version.ps1
@@ -2,4 +2,4 @@
 # The .NET Foundation licenses this file to you under the MIT license.
 # See the LICENSE file in the project root for more information.
 
-$script:versionString = "v0.26.0-beta.1"
+$script:versionString = "v0.26.0-beta.4"


### PR DESCRIPTION
To test, build a local image using ./scripts/local-docker.ps1. Then, create a test folder with inside a folder named `cert`.

Then, run:

```sh
docker run --rm -it -p 8000:8000 -p 8897:8897 -v ${PWD}:/config -v ${PWD}/cert:/home/devproxy/.config/dev-proxy/rootCert dev-proxy-local:0.26.0-beta.4
```

After proxy starts, proxy's pfx will appear in the ./cert folder on the host from which it can be trusted.