### PR TITLE
Fixes processing hosts and URLs to watch

### DIFF
--- a/dev-proxy-abstractions/ProxyUtils.cs
+++ b/dev-proxy-abstractions/ProxyUtils.cs
@@ -356,9 +356,9 @@ public static class ProxyUtils
 
     public static JsonSerializerOptions JsonSerializerOptions => jsonSerializerOptions;
 
-    public static bool MatchesUrlToWatch(ISet<UrlToWatch> watchedUrls, string url)
+    public static bool MatchesUrlToWatch(ISet<UrlToWatch> watchedUrls, string url, bool evaluateWildcards = false)
     {
-        if (url.Contains('*'))
+        if (evaluateWildcards && url.Contains('*'))
         {
             // url contains a wildcard, so convert it to regex and compare
             var match = watchedUrls.FirstOrDefault(r => {

--- a/dev-proxy-plugins/Mocks/CrudApiPlugin.cs
+++ b/dev-proxy-plugins/Mocks/CrudApiPlugin.cs
@@ -101,7 +101,7 @@ public class CrudApiPlugin(IPluginEvents pluginEvents, IProxyContext context, IL
             _configuration.Auth = CrudApiAuthType.None;
         }
 
-        if (!ProxyUtils.MatchesUrlToWatch(UrlsToWatch, _configuration.BaseUrl))
+        if (!ProxyUtils.MatchesUrlToWatch(UrlsToWatch, _configuration.BaseUrl, true))
         {
             Logger.LogWarning(
                 "The base URL of the API {baseUrl} does not match any URL to watch. The {plugin} plugin will be disabled. To enable it, add {url}* to the list of URLs to watch and restart Dev Proxy.",

--- a/dev-proxy-plugins/Mocks/MockResponsePlugin.cs
+++ b/dev-proxy-plugins/Mocks/MockResponsePlugin.cs
@@ -137,7 +137,7 @@ public class MockResponsePlugin(IPluginEvents pluginEvents, IProxyContext contex
                 continue;
             }
 
-            if (!ProxyUtils.MatchesUrlToWatch(UrlsToWatch, mock.Request.Url))
+            if (!ProxyUtils.MatchesUrlToWatch(UrlsToWatch, mock.Request.Url, true))
             {
                 unmatchedMockUrls.Add(mock.Request.Url);
             }

--- a/dev-proxy-plugins/RandomErrors/GenericRandomErrorPlugin.cs
+++ b/dev-proxy-plugins/RandomErrors/GenericRandomErrorPlugin.cs
@@ -268,7 +268,7 @@ public class GenericRandomErrorPlugin(IPluginEvents pluginEvents, IProxyContext 
                 continue;
             }
 
-            if (!ProxyUtils.MatchesUrlToWatch(UrlsToWatch, error.Request.Url))
+            if (!ProxyUtils.MatchesUrlToWatch(UrlsToWatch, error.Request.Url, true))
             {
                 unmatchedErrorUrls.Add(error.Request.Url);
             }


### PR DESCRIPTION
This PR fixes processing hosts- and URLs to watch.

For hosts to watch, it fixes properly handling excluded URLs. Previously, excluded URLs were ignored altogether. So if you configured URLs to watch like:

```json
  "urlsToWatch": [
    "!https://login.microsoftonline.com/*",
    "!https://*.applicationinsights.azure.com/*",
    "*"
  ],
```

you'd end up with decrypting SSL for all URLs, because the first two exclusions are ignored.

The second part of the fix is related to processing URLs to watch. Recently, we've added validating mocks to ensure that they're covered by URLs to watch and give an early warning if that's not the case. However, the fix breaks proxy in case an intercepted URL contains a wildcard, such as `GET https://contoso.sharepoint.com/_api/web/lists?$expand=RootFolder&$select=RootFolder/ServerRelativeUrl,*`. It would treat the URL as a wildcard which leads to incorrect comparison and in the end, ignoring the URL. This PR adds differentiation between validating mocks on startup and evaluating intercepted URLs.