### PR TITLE
Fixes generating TypeSpec files

### DIFF
--- a/dev-proxy-abstractions/LanguageModel/OllamaLanguageModelClient.cs
+++ b/dev-proxy-abstractions/LanguageModel/OllamaLanguageModelClient.cs
@@ -45,7 +45,7 @@ public class OllamaLanguageModelClient(LanguageModelConfiguration? configuration
             _logger.LogError("Model is not set. Language model will be disabled");
             return false;
         }
-        
+
         _logger.LogDebug("Checking LM availability at {url}...", _configuration.Url);
 
         try
@@ -132,13 +132,16 @@ public class OllamaLanguageModelClient(LanguageModelConfiguration? configuration
                     options
                 }
             );
-            _logger.LogDebug("Response: {response}", response.StatusCode);
+            _logger.LogDebug("Response status: {response}", response.StatusCode);
 
             var res = await response.Content.ReadFromJsonAsync<OllamaLanguageModelCompletionResponse>();
             if (res is null)
             {
+                _logger.LogDebug("Response: null");
                 return res;
             }
+
+            _logger.LogDebug("Response: {response}", res.Response);
 
             res.RequestUrl = url;
             return res;
@@ -217,7 +220,7 @@ public class OllamaLanguageModelClient(LanguageModelConfiguration? configuration
                 }
             );
             _logger.LogDebug("Response: {response}", response.StatusCode);
-            
+
             var res = await response.Content.ReadFromJsonAsync<OllamaLanguageModelChatCompletionResponse>();
             if (res is null)
             {

--- a/dev-proxy-plugins/TypeSpec/Http.cs
+++ b/dev-proxy-plugins/TypeSpec/Http.cs
@@ -136,7 +136,7 @@ internal class Model
 internal class ModelProperty
 {
     public required string Name { get; init; }
-    public required string Type { get; init; }
+    public required string Type { get; set; }
 
     override public string ToString()
     {

--- a/dev-proxy-plugins/TypeSpec/TypeSpecExtensions.cs
+++ b/dev-proxy-plugins/TypeSpec/TypeSpecExtensions.cs
@@ -17,9 +17,14 @@ static class TypeSpecExtensions
 
         foreach (var prop in model.Properties)
         {
-            if (!existingModel.Properties.Any(p => p.Name == prop.Name))
+            var existingProp = existingModel.Properties.FirstOrDefault(p => p.Name == prop.Name);
+            if (existingProp is null)
             {
                 existingModel.Properties.Add(prop);
+            }
+            else if (existingProp.Type == "null")
+            {
+                existingProp.Type = prop.Type;
             }
         }
 


### PR DESCRIPTION
Fixes generating TypeSpec files:
- adds sanitizing namespaces, and model- and operation names
- fixes handling null types
- fixes generating models from array items
- fixes sanitizing names when using language model

Thanks @tomorgan for reporting these issues and working with us to get them fixed!