### PR TITLE
Adds support for auth in generating TypeSpec. Closes #1148

### DIFF
--- a/dev-proxy-plugins/Http.cs
+++ b/dev-proxy-plugins/Http.cs
@@ -234,7 +234,7 @@ internal static class Http
         "secret",
         "x-secret",
         "access-key",
-        "api-key",
-        "apikey"
+        "apikey",
+        "code"
     ];
 }

--- a/dev-proxy-plugins/RequestLogs/TypeSpecGeneratorPlugin.cs
+++ b/dev-proxy-plugins/RequestLogs/TypeSpecGeneratorPlugin.cs
@@ -7,9 +7,12 @@ using DevProxy.Abstractions.LanguageModel;
 using DevProxy.Plugins.TypeSpec;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Web;
+using Titanium.Web.Proxy.Http;
 
 namespace DevProxy.Plugins.RequestLogs;
 
@@ -72,14 +75,11 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
                 continue;
             }
 
-            var httpRequest = request.Context.Session.HttpClient.Request;
-            var httpResponse = request.Context.Session.HttpClient.Response;
-
             var methodAndUrlString = request.Message;
             Logger.LogDebug("Processing request {methodAndUrlString}...", methodAndUrlString);
 
             var url = new Uri(request.Url);
-            var doc = await GetOrCreateTypeSpecFile(typeSpecFiles, url);
+            var doc = await GetOrCreateTypeSpecFileAsync(typeSpecFiles, url);
 
             var serverUrl = url.GetLeftPart(UriPartial.Authority);
             if (!doc.Service.Servers.Any(x => x.Url.Equals(serverUrl, StringComparison.InvariantCultureIgnoreCase)))
@@ -90,99 +90,7 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
                 });
             }
 
-            var (route, parameters) = await GetRouteAndParameters(url);
-            var op = new Operation
-            {
-                Name = await GetOperationName(request.Method, url),
-                Description = await GetOperationDescription(request.Method, url),
-                Method = Enum.Parse<HttpVerb>(request.Method, true),
-                Route = route,
-            };
-            op.Parameters.AddRange(parameters);
-
-            var lastSegment = GetLastNonParametrizableSegment(url);
-            if (httpRequest.HasBody)
-            {
-                var models = await GetModelsFromString(httpRequest.BodyString, lastSegment.ToPascalCase());
-                if (models.Length > 0)
-                {
-                    foreach (var model in models)
-                    {
-                        doc.Service.Namespace.MergeModel(model);
-                    }
-
-                    var rootModel = models.Last();
-                    op.Parameters.Add(new()
-                    {
-                        Name = await GetParameterName(rootModel),
-                        Value = rootModel.Name,
-                        In = ParameterLocation.Body
-                    });
-                }
-            }
-
-            foreach (var header in httpRequest.Headers)
-            {
-                if (Http.StandardHeaders.Contains(header.Name.ToLowerInvariant()) ||
-                    Http.AuthHeaders.Contains(header.Name.ToLowerInvariant()))
-                {
-                    continue;
-                }
-
-                op.Parameters.Add(new()
-                {
-                    Name = Parameter.GetHeaderName(header.Name),
-                    Value = header.Value,
-                    In = ParameterLocation.Header
-                });
-            }
-
-            if (httpResponse is not null)
-            {
-                OperationResponseModel res;
-
-                if (_configuration.IgnoreResponseTypes)
-                {
-                    res = new OperationResponseModel
-                    {
-                        StatusCode = httpResponse.StatusCode,
-                        BodyType = "string"
-                    };
-                }
-                else
-                {
-                    res = new OperationResponseModel
-                    {
-                        StatusCode = httpResponse.StatusCode,
-                        Headers = httpResponse.Headers
-                            .Where(h => !Http.StandardHeaders.Contains(h.Name.ToLowerInvariant()) &&
-                                        !Http.AuthHeaders.Contains(h.Name.ToLowerInvariant()))
-                            .ToDictionary(h => h.Name.ToCamelCase(), h => h.Value.GetType().Name)
-                    };
-
-                    var models = await GetModelsFromString(httpResponse.BodyString, lastSegment.ToPascalCase(), httpResponse.StatusCode >= 400);
-                    if (models.Length > 0)
-                    {
-                        foreach (var model in models)
-                        {
-                            doc.Service.Namespace.MergeModel(model);
-                        }
-
-                        var rootModel = models.Last();
-                        if (rootModel.IsArray)
-                        {
-                            res.BodyType = $"{rootModel.Name}[]";
-                            op.Name = await GetOperationName("list", url);
-                        }
-                        else
-                        {
-                            res.BodyType = rootModel.Name;
-                        }
-                    }
-                }
-
-                op.MergeResponse(res);
-            }
+            var op = await GetOperationAsync(request, doc);
 
             doc.Service.Namespace.MergeOperation(op);
         }
@@ -213,25 +121,320 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         e.GlobalData[GeneratedTypeSpecFilesKey] = generatedTypeSpecFiles;
     }
 
-    private async Task<string> GetParameterName(Model model)
+    private async Task<Operation> GetOperationAsync(RequestLog request, TypeSpecFile doc)
     {
-        Logger.LogTrace("Entered GetParameterName");
+        Logger.LogTrace("Entered {name}", nameof(GetOperationAsync));
 
-        var name = model.IsArray ? SanitizeName(await MakeSingular(model.Name)) : model.Name;
+        Debug.Assert(request.Context is not null, "request.Context is null");
+        Debug.Assert(request.Method is not null, "request.Method is null");
+        Debug.Assert(request.Url is not null, "request.Url is null");
+
+        var url = new Uri(request.Url);
+        var httpRequest = request.Context.Session.HttpClient.Request;
+        var httpResponse = request.Context.Session.HttpClient.Response;
+
+        var (route, parameters) = await GetRouteAndParametersAsync(url);
+        var op = new Operation
+        {
+            Name = await GetOperationNameAsync(request.Method, url),
+            Description = await GetOperationDescriptionAsync(request.Method, url),
+            Method = Enum.Parse<HttpVerb>(request.Method, true),
+            Route = route,
+            Doc = doc
+        };
+        op.Parameters.AddRange(parameters);
+
+        var lastSegment = GetLastNonParametrizableSegment(url);
+        await ProcessRequestBodyAsync(httpRequest, doc, op, lastSegment);
+        ProcessRequestHeaders(httpRequest, op);
+        ProcessAuth(httpRequest, doc, op);
+        await ProcessResponseAsync(httpResponse, doc, op, lastSegment, url);
+
+        Logger.LogTrace("Left {name}", nameof(GetOperationAsync));
+
+        return op;
+    }
+
+    private void ProcessAuth(Request httpRequest, TypeSpecFile doc, Operation op)
+    {
+        Logger.LogTrace("Entered {name}", nameof(ProcessAuth));
+
+        var authHeaders = httpRequest.Headers
+            .Where(h => Http.AuthHeaders.Contains(h.Name.ToLowerInvariant()))
+            .Select(h => (h.Name, h.Value));
+
+        foreach (var (name, value) in authHeaders)
+        {
+            if (name.Equals("cookie", StringComparison.InvariantCultureIgnoreCase))
+            {
+                continue;
+            }
+
+            if (!name.Equals("authorization", StringComparison.InvariantCultureIgnoreCase) ||
+                !value.StartsWith("Bearer ", StringComparison.InvariantCultureIgnoreCase))
+            {
+                AddApiKeyAuth(op, name, ApiKeyLocation.Header);
+                return;
+            }
+
+            var bearerToken = value["Bearer ".Length..].Trim();
+            AddAuthorizationAuth(op, bearerToken, doc);
+            return;
+        }
+
+        var query = HttpUtility.ParseQueryString(httpRequest.RequestUri.Query);
+        var authQueryParam = query.AllKeys
+            .Where(k => k is not null && Http.AuthHeaders.Contains(k.ToLowerInvariant()))
+            .FirstOrDefault();
+        if (authQueryParam is not null)
+        {
+            Logger.LogDebug("Found auth query parameter: {authQueryParam}", authQueryParam);
+            AddApiKeyAuth(op, authQueryParam, ApiKeyLocation.Query);
+        }
+        else
+        {
+            Logger.LogDebug("No auth headers or query parameters found");
+        }
+
+        Logger.LogTrace("Left {name}", nameof(ProcessAuth));
+    }
+
+    private void AddAuthorizationAuth(Operation op, string bearerToken, TypeSpecFile doc)
+    {
+        Logger.LogTrace("Entered {name}", nameof(AddAuthorizationAuth));
+
+        if (IsJwtToken(bearerToken, out var jwtToken))
+        {
+            var issuer = jwtToken.Issuer;
+            Logger.LogDebug("Issuer: {issuer}", issuer);
+            var scopes = jwtToken.Claims
+                .Where(c => c.Type == "scp")
+                .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                .Distinct()
+                .ToList();
+            Logger.LogDebug("Scopes: {scopes}", string.Join(", ", scopes));
+            var roles = jwtToken.Claims
+                .Where(c => c.Type == "roles")
+                .SelectMany(c => c.Value.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                .Distinct();
+            Logger.LogDebug("Roles: {roles}", string.Join(", ", roles));
+            scopes.AddRange(roles);
+
+            OAuth2Auth? auth = null;
+            if (IsEntraToken(issuer))
+            {
+                var version = jwtToken.Claims
+                    .FirstOrDefault(c => c.Type == "ver")?.Value ?? "1.0";
+                var baseUrl = issuer.Contains("v2.0") ? issuer.Replace("v2.0", "") : issuer;
+                auth = new OAuth2Auth
+                {
+                    Name = $"EntraOAuth2Auth",
+                    FlowType = roles.Any() ? FlowType.ClientCredentials : FlowType.AuthorizationCode,
+                    TokenUrl = version == "1.0" ? $"{baseUrl}oauth2/token" : $"{baseUrl}oauth2/v2.0/token",
+                    AuthorizationUrl = version == "1.0" ? $"{baseUrl}oauth2/authorize" : $"{baseUrl}oauth2/v2.0/authorize",
+                    RefreshUrl = version == "1.0" ? $"{baseUrl}oauth2/token" : $"{baseUrl}oauth2/v2.0/token",
+                    Scopes = [.. scopes]
+                };
+            }
+            else
+            {
+                auth = new OAuth2Auth
+                {
+                    Name = $"APIOAuth2Auth",
+                    FlowType = FlowType.AuthorizationCode,
+                    TokenUrl = jwtToken.Issuer,
+                    AuthorizationUrl = jwtToken.Issuer,
+                    Scopes = [.. scopes]
+                };
+            }
+            doc.Service.Namespace.Auth = auth;
+            op.Auth = auth;
+        }
+        else
+        {
+            op.Auth = new BearerAuth();
+        }
+
+        Logger.LogTrace("Left {name}", nameof(AddAuthorizationAuth));
+    }
+
+    private bool IsEntraToken(string issuer)
+    {
+        Logger.LogTrace("Entered {name}", nameof(IsEntraToken));
+
+        var isEntraToken = issuer.Contains("https://login.microsoftonline.com/") ||
+            issuer.Contains("https://sts.windows.net/");
+
+        Logger.LogDebug("Is token from Entra? {isEntraToken}", isEntraToken);
+        Logger.LogTrace("Left {name}", nameof(IsEntraToken));
+
+        return isEntraToken;
+    }
+
+    private void AddApiKeyAuth(Operation op, string name, ApiKeyLocation location)
+    {
+        Logger.LogTrace("Entered {name}", nameof(AddApiKeyAuth));
+
+        var apiKeyAuth = new ApiKeyAuth
+        {
+            Name = name,
+            In = location
+        };
+        op.Auth = apiKeyAuth;
+
+        Logger.LogTrace("Left {name}", nameof(AddApiKeyAuth));
+    }
+
+    private bool IsJwtToken(string bearerToken, out JwtSecurityToken jwtToken)
+    {
+        Logger.LogTrace("Entered {name}", nameof(IsJwtToken));
+
+        jwtToken = new();
+
+        try
+        {
+            jwtToken = new JwtSecurityToken(bearerToken);
+            Logger.LogTrace("Left {name}", nameof(IsJwtToken));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug("Failed to parse JWT token: {ex}", ex.Message);
+        }
+
+        Logger.LogTrace("Left {name}", nameof(IsJwtToken));
+        return false;
+    }
+
+    private async Task ProcessRequestBodyAsync(Request httpRequest, TypeSpecFile doc, Operation op, string lastSegment)
+    {
+        Logger.LogTrace("Entered {name}", nameof(ProcessRequestBodyAsync));
+
+        if (!httpRequest.HasBody)
+        {
+            Logger.LogDebug("Request has no body, skipping...");
+            return;
+        }
+
+        var models = await GetModelsFromStringAsync(httpRequest.BodyString, lastSegment.ToPascalCase());
+        if (models.Length > 0)
+        {
+            foreach (var model in models)
+            {
+                doc.Service.Namespace.MergeModel(model);
+            }
+
+            var rootModel = models.Last();
+            op.Parameters.Add(new()
+            {
+                Name = await GetParameterNameAsync(rootModel),
+                Value = rootModel.Name,
+                In = ParameterLocation.Body
+            });
+        }
+
+        Logger.LogTrace("Left {name}", nameof(ProcessRequestBodyAsync));
+    }
+
+    private void ProcessRequestHeaders(Request httpRequest, Operation op)
+    {
+        Logger.LogTrace("Entered {name}", nameof(ProcessRequestHeaders));
+
+        foreach (var header in httpRequest.Headers)
+        {
+            if (Http.StandardHeaders.Contains(header.Name.ToLowerInvariant()) ||
+                Http.AuthHeaders.Contains(header.Name.ToLowerInvariant()))
+            {
+                continue;
+            }
+
+            op.Parameters.Add(new()
+            {
+                Name = header.Name,
+                Value = GetValueType(header.Value),
+                In = ParameterLocation.Header
+            });
+        }
+
+        Logger.LogTrace("Left {name}", nameof(ProcessRequestHeaders));
+    }
+
+    private async Task ProcessResponseAsync(Response? httpResponse, TypeSpecFile doc, Operation op, string lastSegment, Uri url)
+    {
+        Logger.LogTrace("Entered {name}", nameof(ProcessResponseAsync));
+
+        if (httpResponse is null)
+        {
+            Logger.LogDebug("Response is null, skipping...");
+            return;
+        }
+
+        OperationResponseModel res;
+
+        if (_configuration.IgnoreResponseTypes)
+        {
+            res = new OperationResponseModel
+            {
+                StatusCode = httpResponse.StatusCode,
+                BodyType = "string"
+            };
+        }
+        else
+        {
+            res = new OperationResponseModel
+            {
+                StatusCode = httpResponse.StatusCode,
+                Headers = httpResponse.Headers
+                    .Where(h => !Http.StandardHeaders.Contains(h.Name.ToLowerInvariant()) &&
+                                !Http.AuthHeaders.Contains(h.Name.ToLowerInvariant()))
+                    .ToDictionary(h => h.Name.ToCamelCase(), h => h.Value.GetType().Name)
+            };
+
+            var models = await GetModelsFromStringAsync(httpResponse.BodyString, lastSegment.ToPascalCase(), httpResponse.StatusCode >= 400);
+            if (models.Length > 0)
+            {
+                foreach (var model in models)
+                {
+                    doc.Service.Namespace.MergeModel(model);
+                }
+
+                var rootModel = models.Last();
+                if (rootModel.IsArray)
+                {
+                    res.BodyType = $"{rootModel.Name}[]";
+                    op.Name = await GetOperationNameAsync("list", url);
+                }
+                else
+                {
+                    res.BodyType = rootModel.Name;
+                }
+            }
+        }
+
+        op.MergeResponse(res);
+
+        Logger.LogTrace("Left {name}", nameof(ProcessResponseAsync));
+    }
+
+    private async Task<string> GetParameterNameAsync(Model model)
+    {
+        Logger.LogTrace("Entered {name}", nameof(GetParameterNameAsync));
+
+        var name = model.IsArray ? SanitizeName(await MakeSingularAsync(model.Name)) : model.Name;
         if (string.IsNullOrEmpty(name))
         {
             name = model.Name;
         }
 
         Logger.LogDebug("Parameter name: {name}", name);
-        Logger.LogTrace("Left GetParameterName");
+        Logger.LogTrace("Left {name}", nameof(GetParameterNameAsync));
 
         return name;
     }
 
-    private async Task<TypeSpecFile> GetOrCreateTypeSpecFile(List<TypeSpecFile> files, Uri url)
+    private async Task<TypeSpecFile> GetOrCreateTypeSpecFileAsync(List<TypeSpecFile> files, Uri url)
     {
-        Logger.LogTrace("Entered GetOrCreateTypeSpecFile");
+        Logger.LogTrace("Entered {name}", nameof(GetOrCreateTypeSpecFileAsync));
 
         var name = GetName(url);
         Logger.LogDebug("Name: {name}", name);
@@ -240,7 +443,7 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         {
             Logger.LogDebug("Creating new TypeSpec file: {name}", name);
 
-            var serviceTitle = await GetServiceTitle(url);
+            var serviceTitle = await GetServiceTitleAsync(url);
             file = new TypeSpecFile
             {
                 Name = name,
@@ -260,14 +463,14 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
             Logger.LogDebug("Using existing TypeSpec file: {name}", name);
         }
 
-        Logger.LogTrace("Left GetOrCreateTypeSpecFile");
+        Logger.LogTrace("Left {name}", nameof(GetOrCreateTypeSpecFileAsync));
 
         return file;
     }
 
     private string GetRootNamespaceName(Uri url)
     {
-        Logger.LogTrace("Entered GetRootNamespaceName");
+        Logger.LogTrace("Entered {name}", nameof(GetRootNamespaceName));
 
         var ns = SanitizeName(string.Join("", url.Host.Split('.').Select(x => x.ToPascalCase())));
         if (string.IsNullOrEmpty(ns))
@@ -276,20 +479,20 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         }
 
         Logger.LogDebug("Root namespace name: {ns}", ns);
-        Logger.LogTrace("Left GetRootNamespaceName");
+        Logger.LogTrace("Left {name}", nameof(GetRootNamespaceName));
 
         return ns;
     }
 
-    private async Task<string> GetOperationName(string method, Uri url)
+    private async Task<string> GetOperationNameAsync(string method, Uri url)
     {
-        Logger.LogTrace("Entered GetOperationName");
+        Logger.LogTrace("Entered {name}", nameof(GetOperationNameAsync));
 
         var lastSegment = GetLastNonParametrizableSegment(url);
         Logger.LogDebug("Url: {url}", url);
         Logger.LogDebug("Last non-parametrizable segment: {lastSegment}", lastSegment);
 
-        var name = method == "list" ? lastSegment : await MakeSingular(lastSegment);
+        var name = method == "list" ? lastSegment : await MakeSingularAsync(lastSegment);
         if (string.IsNullOrEmpty(name))
         {
             name = lastSegment;
@@ -313,26 +516,26 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         }
 
         Logger.LogDebug("Operation name: {operationName}", operationName);
-        Logger.LogTrace("Left GetOperationName");
+        Logger.LogTrace("Left {name}", nameof(GetOperationNameAsync));
 
         return operationName;
     }
 
     private string GetRandomName()
     {
-        Logger.LogTrace("Entered GetRandomName");
+        Logger.LogTrace("Entered {name}", nameof(GetRandomName));
 
         var name = Guid.NewGuid().ToString("N");
 
         Logger.LogDebug("Random name: {name}", name);
-        Logger.LogTrace("Left GetRandomName");
+        Logger.LogTrace("Left {name}", nameof(GetRandomName));
 
         return name;
     }
 
-    private async Task<string> GetOperationDescription(string method, Uri url)
+    private async Task<string> GetOperationDescriptionAsync(string method, Uri url)
     {
-        Logger.LogTrace("Entered GetOperationDescription");
+        Logger.LogTrace("Entered {name}", nameof(GetOperationDescriptionAsync));
 
         var prompt = $"You're an expert in OpenAPI. You help developers build great OpenAPI specs for use with LLMs. For the specified request, generate a one-sentence description. Respond with just the description. For example, for a request such as `GET https://api.contoso.com/books/{{books-id}}` you return `Get a book by ID`. Request: {method.ToUpper()} {url}";
         ILanguageModelCompletionResponse? description = null;
@@ -344,26 +547,26 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         var operationDescription = description?.Response ?? $"{method.ToUpperInvariant()} {url}";
 
         Logger.LogDebug("Operation description: {operationDescription}", operationDescription);
-        Logger.LogTrace("Left GetOperationDescription");
+        Logger.LogTrace("Left {name}", nameof(GetOperationDescriptionAsync));
 
         return operationDescription;
     }
 
     private string GetName(Uri url)
     {
-        Logger.LogTrace("Entered GetName");
+        Logger.LogTrace("Entered {name}", nameof(GetName));
 
         var name = url.Host.Replace(".", "-").ToKebabCase();
 
         Logger.LogDebug("Name: {name}", name);
-        Logger.LogTrace("Left GetName");
+        Logger.LogTrace("Left {name}", nameof(GetName));
 
         return name;
     }
 
-    private async Task<string> GetServiceTitle(Uri url)
+    private async Task<string> GetServiceTitleAsync(Uri url)
     {
-        Logger.LogTrace("Entered GetServiceTitle");
+        Logger.LogTrace("Entered {name}", nameof(GetServiceTitleAsync));
 
         var prompt = $"Based on the following host name, generate a descriptive name of an API service hosted on this URL. Respond with just the name. Host name: {url.Host}";
         ILanguageModelCompletionResponse? serviceTitle = null;
@@ -374,14 +577,14 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         var st = serviceTitle?.Response?.Trim('"') ?? $"{url.Host.Split('.').First().ToPascalCase()} API";
 
         Logger.LogDebug("Service title: {st}", st);
-        Logger.LogTrace("Left GetServiceTitle");
+        Logger.LogTrace("Left {name}", nameof(GetServiceTitleAsync));
 
         return st;
     }
 
     private string GetLastNonParametrizableSegment(Uri url)
     {
-        Logger.LogTrace("Entered GetLastNonParametrizableSegment");
+        Logger.LogTrace("Entered {name}", nameof(GetLastNonParametrizableSegment));
 
         var segments = url.Segments;
         for (int i = segments.Length - 1; i >= 0; i--)
@@ -390,34 +593,34 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
             if (!IsParametrizable(segment))
             {
                 Logger.LogDebug("Last non-parametrizable segment: {segment}", segment);
-                Logger.LogTrace("Left GetLastNonParametrizableSegment");
+                Logger.LogTrace("Left {name}", nameof(GetLastNonParametrizableSegment));
 
                 return segment;
             }
         }
 
         Logger.LogDebug("No non-parametrizable segment found, returning empty string");
-        Logger.LogTrace("Left GetLastNonParametrizableSegment");
+        Logger.LogTrace("Left {name}", nameof(GetLastNonParametrizableSegment));
 
         return string.Empty;
     }
 
     private bool IsParametrizable(string segment)
     {
-        Logger.LogTrace("Entered IsParametrizable");
+        Logger.LogTrace("Entered {name}", nameof(IsParametrizable));
 
         var isParametrizable = Guid.TryParse(segment, out _) ||
           int.TryParse(segment, out _);
 
         Logger.LogDebug("Is segment '{segment}' parametrizable? {isParametrizable}", segment, isParametrizable);
-        Logger.LogTrace("Left IsParametrizable");
+        Logger.LogTrace("Left {name}", nameof(IsParametrizable));
 
         return isParametrizable;
     }
 
-    private async Task<(string Route, Parameter[] Parameters)> GetRouteAndParameters(Uri url)
+    private async Task<(string Route, Parameter[] Parameters)> GetRouteAndParametersAsync(Uri url)
     {
-        Logger.LogTrace("Entered GetRouteAndParameters");
+        Logger.LogTrace("Entered {name}", nameof(GetRouteAndParametersAsync));
 
         var route = new List<string>();
         var parameters = new List<Parameter>();
@@ -439,14 +642,14 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
                 parameters.Add(new Parameter
                 {
                     Name = paramName,
-                    Value = "string",
+                    Value = GetValueType(segmentTrimmed),
                     In = ParameterLocation.Path
                 });
                 route.Add($"{{{paramName}}}");
             }
             else
             {
-                previousSegment = SanitizeName(await MakeSingular(segmentTrimmed));
+                previousSegment = SanitizeName(await MakeSingularAsync(segmentTrimmed));
                 if (string.IsNullOrEmpty(previousSegment))
                 {
                     previousSegment = SanitizeName(segmentTrimmed);
@@ -467,10 +670,16 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
             var query = HttpUtility.ParseQueryString(url.Query);
             foreach (string key in query.Keys)
             {
+                if (Http.AuthHeaders.Contains(key.ToLowerInvariant()))
+                {
+                    Logger.LogDebug("Skipping auth header: {key}", key);
+                    continue;
+                }
+
                 parameters.Add(new()
                 {
-                    Name = key.ToCamelCase(),
-                    Value = "string",
+                    Name = key.ToCamelFromKebabCase(),
+                    Value = GetValueType(query[key]),
                     In = ParameterLocation.Query
                 });
             }
@@ -480,18 +689,19 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
             Logger.LogDebug("No query string found in URL: {url}", url);
         }
 
-        Logger.LogTrace("Left GetRouteAndParameters");
+        Logger.LogTrace("Left {name}", nameof(GetRouteAndParametersAsync));
 
         return (string.Join('/', route), parameters.ToArray());
     }
 
-    private async Task<Model[]> GetModelsFromString(string? str, string name, bool isError = false)
+    private async Task<Model[]> GetModelsFromStringAsync(string? str, string name, bool isError = false)
     {
-        Logger.LogTrace("Entered GetModelsFromString");
+        Logger.LogTrace("Entered {name}", nameof(GetModelsFromStringAsync));
 
         if (string.IsNullOrEmpty(str))
         {
             Logger.LogDebug("Empty string, returning empty model list");
+            Logger.LogTrace("Left {name}", nameof(GetModelsFromStringAsync));
             return [];
         }
 
@@ -501,31 +711,32 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         {
             using var doc = JsonDocument.Parse(str);
             JsonElement root = doc.RootElement;
-            await AddModelFromJsonElement(root, name, isError, models);
+            await AddModelFromJsonElementAsync(root, name, isError, models);
         }
         catch (Exception ex)
         {
             Logger.LogDebug("Failed to parse JSON string, returning empty model list. Exception: {ex}", ex.Message);
 
             // If the string is not a valid JSON, we return an empty model list
+            Logger.LogTrace("Left {name}", nameof(GetModelsFromStringAsync));
             return [];
         }
 
-        Logger.LogTrace("Left GetModelsFromString");
+        Logger.LogTrace("Left {name}", nameof(GetModelsFromStringAsync));
 
         return [.. models];
     }
 
-    private async Task<string> AddModelFromJsonElement(JsonElement jsonElement, string name, bool isError, List<Model> models)
+    private async Task<string> AddModelFromJsonElementAsync(JsonElement jsonElement, string name, bool isError, List<Model> models)
     {
-        Logger.LogTrace("Entered AddModelFromJsonElement");
+        Logger.LogTrace("Entered {name}", nameof(AddModelFromJsonElementAsync));
 
         switch (jsonElement.ValueKind)
         {
             case JsonValueKind.String:
                 return "string";
             case JsonValueKind.Number:
-                return "int32";
+                return "numeric";
             case JsonValueKind.True:
             case JsonValueKind.False:
                 return "boolean";
@@ -542,7 +753,7 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
 
                 var model = new Model
                 {
-                    Name = await GetModelName(name),
+                    Name = await GetModelNameAsync(name),
                     IsError = isError
                 };
 
@@ -551,7 +762,7 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
                     var property = new ModelProperty
                     {
                         Name = p.Name,
-                        Type = await AddModelFromJsonElement(p.Value, p.Name.ToPascalCase(), isError, models)
+                        Type = await AddModelFromJsonElementAsync(p.Value, p.Name.ToPascalCase(), isError, models)
                     };
                     model.Properties.Add(property);
                 }
@@ -564,13 +775,13 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
                 var modelName = string.Empty;
                 foreach (var item in jsonElement.EnumerateArray())
                 {
-                    modelName = await AddModelFromJsonElement(item, name, isError, models);
+                    modelName = await AddModelFromJsonElementAsync(item, name, isError, models);
                 }
                 models.Add(new Model
                 {
                     Name = modelName,
                     IsError = isError,
-                    IsArray = true,
+                    IsArray = true
                 });
                 return $"{modelName}[]";
             case JsonValueKind.Null:
@@ -580,11 +791,11 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         }
     }
 
-    private async Task<string> GetModelName(string name)
+    private async Task<string> GetModelNameAsync(string name)
     {
-        Logger.LogTrace("Entered GetModelName");
+        Logger.LogTrace("Entered {name}", nameof(GetModelNameAsync));
 
-        var modelName = SanitizeName(await MakeSingular(name));
+        var modelName = SanitizeName(await MakeSingularAsync(name));
         if (string.IsNullOrEmpty(modelName))
         {
             modelName = SanitizeName(name);
@@ -597,14 +808,14 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         modelName = modelName.ToPascalCase();
 
         Logger.LogDebug("Model name: {modelName}", modelName);
-        Logger.LogTrace("Left GetModelName");
+        Logger.LogTrace("Left {name}", nameof(GetModelNameAsync));
 
         return modelName;
     }
 
-    private async Task<string> MakeSingular(string noun)
+    private async Task<string> MakeSingularAsync(string noun)
     {
-        Logger.LogTrace("Entered MakeSingular");
+        Logger.LogTrace("Entered {name}", nameof(MakeSingularAsync));
 
         var prompt = $"Make the following noun singular. Respond only with the word and nothing else. Don't translate. Word: {noun}";
         ILanguageModelCompletionResponse? singularNoun = null;
@@ -638,20 +849,48 @@ public class TypeSpecGeneratorPlugin(IPluginEvents pluginEvents, IProxyContext c
         }
 
         Logger.LogDebug("Singular form of '{noun}': {singular}", noun, singular);
-        Logger.LogTrace("Left MakeSingular");
+        Logger.LogTrace("Left {name}", nameof(MakeSingularAsync));
 
         return singular;
     }
 
     private string SanitizeName(string name)
     {
-        Logger.LogTrace("Entered SanitizeName");
+        Logger.LogTrace("Entered {name}", nameof(SanitizeName));
 
         var sanitized = Regex.Replace(name, "[^a-zA-Z0-9_]", "");
 
         Logger.LogDebug("Sanitized name: {name} to: {sanitized}", name, sanitized);
-        Logger.LogTrace("Left SanitizeName");
+        Logger.LogTrace("Left {name}", nameof(SanitizeName));
 
         return sanitized;
+    }
+
+    private string GetValueType(string? value)
+    {
+        Logger.LogTrace("Entered {name}", nameof(GetValueType));
+
+        if (string.IsNullOrEmpty(value))
+        {
+            return "null";
+        }
+        else if (int.TryParse(value, out _))
+        {
+            return "integer";
+        }
+        else if (bool.TryParse(value, out _))
+        {
+            return "boolean";
+        }
+        else if (DateTime.TryParse(value, out _))
+        {
+            return "utcDateTime";
+        }
+        else if (double.TryParse(value, out _))
+        {
+            return "decimal";
+        }
+
+        return "string";
     }
 }

--- a/dev-proxy-plugins/StringExtensions.cs
+++ b/dev-proxy-plugins/StringExtensions.cs
@@ -8,11 +8,33 @@ namespace System;
 
 internal static class StringExtensions
 {
+    /// <summary>
+    /// Truncates the string to the specified maximum length.
+    /// </summary>
+    /// <param name="input">The input string to truncate.</param>
+    /// <param name="maxLength">The maximum allowed length.</param>
+    /// <returns>The truncated string if longer than maxLength; otherwise, the original string.</returns>
+    /// <example>
+    /// <code>
+    /// "HelloWorld".MaxLength(5); // returns "Hello"
+    /// "Hi".MaxLength(5); // returns "Hi"
+    /// </code>
+    /// </example>
     internal static string MaxLength(this string input, int maxLength)
     {
         return input.Length <= maxLength ? input : input[..maxLength];
     }
 
+    /// <summary>
+    /// Converts the first character of the string to uppercase (PascalCase).
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <returns>The string converted to PascalCase.</returns>
+    /// <example>
+    /// <code>
+    /// "helloWorld".ToPascalCase(); // returns "HelloWorld"
+    /// </code>
+    /// </example>
     internal static string ToPascalCase(this string input)
     {
         if (string.IsNullOrEmpty(input))
@@ -23,6 +45,16 @@ internal static class StringExtensions
         return char.ToUpper(input[0]) + input[1..];
     }
 
+    /// <summary>
+    /// Converts the first character of the string to lowercase (camelCase).
+    /// </summary>
+    /// <param name="str">The input string.</param>
+    /// <returns>The string converted to camelCase.</returns>
+    /// <example>
+    /// <code>
+    /// "HelloWorld".ToCamelCase(); // returns "helloWorld"
+    /// </code>
+    /// </example>
     internal static string ToCamelCase(this string str)
     {
         if (string.IsNullOrEmpty(str))
@@ -31,6 +63,16 @@ internal static class StringExtensions
         return char.ToLowerInvariant(str[0]) + str[1..];
     }
 
+    /// <summary>
+    /// Converts the string to kebab-case.
+    /// </summary>
+    /// <param name="str">The input string.</param>
+    /// <returns>The string converted to kebab-case.</returns>
+    /// <example>
+    /// <code>
+    /// "HelloWorld".ToKebabCase(); // returns "hello-world"
+    /// </code>
+    /// </example>
     internal static string ToKebabCase(this string str)
     {
         if (string.IsNullOrEmpty(str))
@@ -39,6 +81,41 @@ internal static class StringExtensions
         return string.Concat(str.Select((x, i) => i > 0 && char.IsUpper(x) ? "-" + x : x.ToString())).ToLower();
     }
 
+    /// <summary>
+    /// Converts a kebab-case string to camelCase.
+    /// </summary>
+    /// <param name="str">The kebab-case input string.</param>
+    /// <returns>The string converted to camelCase.</returns>
+    /// <example>
+    /// <code>
+    /// "hello-world-example".ToCamelFromKebabCase(); // returns "helloWorldExample"
+    /// </code>
+    /// </example>
+    internal static string ToCamelFromKebabCase(this string str)
+    {
+        if (string.IsNullOrEmpty(str))
+            return str;
+
+        var parts = str.Split('-');
+        if (parts.Length == 0)
+            return str.ToCamelCase();
+
+        return parts[0] + string.Concat(parts.Skip(1).Select(s => char.ToUpperInvariant(s[0]) + s[1..]));
+    }
+
+    /// <summary>
+    /// Replaces occurrences of a specified string with another string, starting from a given index.
+    /// </summary>
+    /// <param name="input">The input string.</param>
+    /// <param name="oldValue">The string to be replaced.</param>
+    /// <param name="newValue">The replacement string.</param>
+    /// <param name="startIndex">The index from which to start replacing.</param>
+    /// <returns>The modified string after replacements.</returns>
+    /// <example>
+    /// <code>
+    /// "HelloWorldHello".Replace("Hello", "Hi", 5); // returns "HelloWorldHi"
+    /// </code>
+    /// </example>
     internal static string Replace(this string input, string oldValue, string newValue, int startIndex)
     {
         if (string.IsNullOrEmpty(input) || string.IsNullOrEmpty(oldValue))

--- a/dev-proxy-plugins/TypeSpec/Auth.cs
+++ b/dev-proxy-plugins/TypeSpec/Auth.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Text;
+
+namespace DevProxy.Plugins.TypeSpec;
+
+internal enum AuthType
+{
+    Http,
+    ApiKey,
+    OAuth2,
+    OpenIdConnect,
+    NoAuth
+}
+
+internal abstract class Auth
+{
+    public abstract AuthType Type { get; }
+}
+
+internal class NoAuth : Auth
+{
+    public override AuthType Type => AuthType.NoAuth;
+
+    public override string ToString()
+    {
+        return "NoAuth";
+    }
+}
+
+internal enum ApiKeyLocation
+{
+    Query,
+    Header,
+    Cookie
+}
+
+internal class ApiKeyAuth : Auth
+{
+    public override AuthType Type => AuthType.ApiKey;
+    public required string Name { get; init; }
+    public required ApiKeyLocation In { get; init; }
+
+    public override string ToString()
+    {
+        return $"ApiKeyAuth<ApiKeyLocation.{In.ToString().ToLowerInvariant()}, \"{Name}\">";
+    }
+}
+
+internal class BearerAuth : Auth
+{
+    public override AuthType Type => AuthType.Http;
+
+    public override string ToString()
+    {
+        return "BearerAuth";
+    }
+}
+
+internal enum FlowType
+{
+    AuthorizationCode,
+    Implicit,
+    Password,
+    ClientCredentials
+}
+
+internal class OAuth2Auth : Auth
+{
+    public string AuthorizationUrl { get; set; } = string.Empty;
+    public override AuthType Type => AuthType.OAuth2;
+    public required FlowType FlowType { get; init; }
+    public required string Name { get; init; }
+    public string[] Scopes { get; set; } = [];
+    public string RefreshUrl { get; set; } = string.Empty;
+    public string TokenUrl { get; set; } = string.Empty;
+
+    override public string ToString()
+    {
+        return $"{Name}<[{string.Join(", ", Scopes.Select(s => $"\"{s}\""))}]>";
+    }
+
+    public string WriteAlias()
+    {
+        static string i(int size) => new(' ', size);
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"alias {Name}<Scopes extends string[]> = OAuth2Auth<");
+        sb.AppendLine($"{i(2)}[");
+        sb.AppendLine($"{i(4)}{{");
+        sb.AppendLine($"{i(6)}type: OAuth2FlowType.{ToFormattedString(FlowType)};");
+        sb.AppendLine($"{i(6)}tokenUrl: \"{TokenUrl}\";");
+        if (FlowType == FlowType.AuthorizationCode)
+        {
+            sb.AppendLine($"{i(6)}authorizationUrl: \"{AuthorizationUrl}\";");
+        }
+        sb.AppendLine($"{i(6)}refreshUrl: \"{RefreshUrl}\";");
+        sb.AppendLine($"{i(4)}}}");
+        sb.AppendLine($"{i(2)}],");
+        sb.AppendLine($"{i(2)}Scopes");
+        sb.AppendLine(">;");
+        return sb.ToString();
+    }
+
+    private static string ToFormattedString(FlowType flowType)
+    {
+        var s = flowType.ToString();
+        return s[0].ToString().ToLowerInvariant() + s[1..];
+    }
+}

--- a/dev-proxy/CommandHandlers/ProxyCommandHandler.cs
+++ b/dev-proxy/CommandHandlers/ProxyCommandHandler.cs
@@ -213,7 +213,10 @@ public class ProxyCommandHandler(IPluginEvents pluginEvents,
             configObject.UrlsToWatch = urlsSection.Get<List<string>>() ?? [];
         }
 
-        configObject.LanguageModel?.Url?.TrimEnd('/');
+        if (configObject.LanguageModel?.Url is not null)
+        {
+            configObject.LanguageModel.Url = configObject.LanguageModel.Url.TrimEnd('/');
+        }
 
         return configObject;
     });


### PR DESCRIPTION
Adds support for auth in generating TypeSpec. Closes #1148

Also:
- fixes bug in using default config for Ollama and its OpenAI-compatible APIs
- fixed bug in caching LLM responses