### PR TITLE
Fixes the warning when using only plugin-specific URLs to watch. Closes #1180

### DIFF
--- a/dev-proxy/CommandHandlers/ProxyCommandHandler.cs
+++ b/dev-proxy/CommandHandlers/ProxyCommandHandler.cs
@@ -37,9 +37,9 @@ public class ProxyCommandHandler(IPluginEvents pluginEvents,
             _logger.LogWarning("You haven't configured any plugins. Please add plugins to your configuration file. Dev Proxy will exit.");
             return 1;
         }
-        if (Configuration.UrlsToWatch.Count == 0)
+        if (_urlsToWatch.Count == 0)
         {
-            _logger.LogWarning("You haven't configured any URLs to watch. Please add URLs to your configuration file or use the --urls-to-watch option. Dev Proxy will exit.");
+            _logger.LogError("You haven't configured any URLs to watch. Please add URLs to your configuration file or use the --urls-to-watch option. Dev Proxy will exit.");
             return 1;
         }
 

--- a/dev-proxy/ProxyEngine.cs
+++ b/dev-proxy/ProxyEngine.cs
@@ -91,7 +91,7 @@ public class ProxyEngine(IProxyConfiguration config, ISet<UrlToWatch> urlsToWatc
 
         if (!_urlsToWatch.Any())
         {
-            _logger.LogInformation("No URLs to watch configured. Please add URLs to watch in the devproxyrc.json config file.");
+            _logger.LogError("No URLs to watch configured. Please add URLs to watch in the devproxyrc.json config file.");
             return;
         }
 


### PR DESCRIPTION
Fixes the warning when using only plugin-specific URLs to watch. Closes #1180