### PR TITLE
Adds skipping non-matching URLs in OpenAITelemetryPlugin

### DIFF
--- a/dev-proxy-plugins/Inspection/OpenAITelemetryPlugin.cs
+++ b/dev-proxy-plugins/Inspection/OpenAITelemetryPlugin.cs
@@ -136,6 +136,12 @@ public class OpenAITelemetryPlugin(IPluginEvents pluginEvents, IProxyContext con
     {
         Logger.LogTrace("OnRequestAsync() called");
 
+        if (UrlsToWatch is null || !e.HasRequestUrlMatch(UrlsToWatch))
+        {
+            Logger.LogRequest("URL not matched", MessageType.Skipped, new LoggingContext(e.Session));
+            return;
+        }
+
         var request = e.Session.HttpClient.Request;
         if (request.Method is null ||
             !request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase) ||

--- a/dev-proxy-plugins/Mocks/OpenAIMockResponsePlugin.cs
+++ b/dev-proxy-plugins/Mocks/OpenAIMockResponsePlugin.cs
@@ -34,15 +34,16 @@ public class OpenAIMockResponsePlugin(IPluginEvents pluginEvents, IProxyContext 
 
     private async Task OnRequestAsync(object sender, ProxyRequestArgs e)
     {
+        if (UrlsToWatch is null ||
+            !e.HasRequestUrlMatch(UrlsToWatch))
+        {
+            Logger.LogRequest("URL not matched", MessageType.Skipped, new LoggingContext(e.Session));
+            return;
+        }
+
         if (e.ResponseState.HasBeenSet)
         {
             Logger.LogRequest("Response already set", MessageType.Skipped, new LoggingContext(e.Session));
-            return;
-        }
-        if (UrlsToWatch is null ||
-            !e.ShouldExecute(UrlsToWatch))
-        {
-            Logger.LogRequest("URL not matched", MessageType.Skipped, new LoggingContext(e.Session));
             return;
         }
 


### PR DESCRIPTION
- Adds skipping non-matching URLs in OpenAITelemetryPlugin
- Changes the order of checks in OpenAIMockResponsePlugin so that checking for matching URLs is done first, which makes more sense.