### PR TITLE
Extends MockResponsePlugin with a command to generate mocks from HTTP responses. Closes #1261

### DIFF
--- a/DevProxy.Abstractions/Models/MockResponse.cs
+++ b/DevProxy.Abstractions/Models/MockResponse.cs
@@ -2,6 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using DevProxy.Abstractions.Utils;
+using Microsoft.Extensions.Logging;
 using System.Text.Json;
 
 namespace DevProxy.Abstractions.Models;
@@ -15,6 +17,103 @@ public class MockResponse : ICloneable
     {
         var json = JsonSerializer.Serialize(this);
         return JsonSerializer.Deserialize<MockResponse>(json) ?? new MockResponse();
+    }
+
+    public static MockResponse FromHttpResponse(string httpResponse, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(FromHttpResponse));
+
+        if (string.IsNullOrWhiteSpace(httpResponse))
+        {
+            throw new ArgumentException("HTTP response cannot be null or empty.", nameof(httpResponse));
+        }
+        if (!httpResponse.StartsWith("HTTP/", StringComparison.Ordinal))
+        {
+            throw new ArgumentException("Invalid HTTP response format. HTTP response must begin with 'HTTP/'", nameof(httpResponse));
+        }
+
+        var lines = httpResponse.Split(["\r\n", "\n"], StringSplitOptions.TrimEntries);
+        var statusCode = 200;
+        List<MockResponseHeader>? responseHeaders = null;
+        dynamic? body = null;
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            logger.LogTrace("Processing line {LineNumber}: {LineContent}", i + 1, line);
+
+            if (i == 0)
+            {
+                // First line is the status line
+                var parts = line.Split(' ', 3);
+                if (parts.Length < 2)
+                {
+                    throw new ArgumentException("Invalid HTTP response format. First line must contain at least HTTP version and status code.", nameof(httpResponse));
+                }
+
+                statusCode = int.TryParse(parts[1], out var _statusCode) ? _statusCode : 200;
+            }
+            else if (string.IsNullOrEmpty(line))
+            {
+                // empty line indicates the end of headers and the start of the body
+                var bodyContents = string.Join("\n", lines.Skip(i + 1));
+                if (string.IsNullOrWhiteSpace(bodyContents))
+                {
+                    continue;
+                }
+
+                var contentType = responseHeaders?.FirstOrDefault(h => h.Name.Equals("Content-Type", StringComparison.OrdinalIgnoreCase))?.Value;
+                if (contentType is not null && contentType.Contains("application/json", StringComparison.OrdinalIgnoreCase))
+                {
+                    try
+                    {
+                        body = JsonSerializer.Deserialize<dynamic>(bodyContents, ProxyUtils.JsonSerializerOptions);
+                    }
+                    catch (JsonException ex)
+                    {
+                        logger.LogError(ex, "Failed to deserialize JSON body from HTTP response");
+                        body = bodyContents;
+                    }
+                }
+                else
+                {
+                    body = bodyContents;
+                }
+
+                break;
+            }
+            else
+            {
+                // Headers
+                var headerParts = line.Split(':', 2);
+                if (headerParts.Length < 2)
+                {
+                    logger.LogError($"Invalid HTTP response header format");
+                    continue;
+                }
+
+                responseHeaders ??= [];
+                responseHeaders.Add(new(headerParts[0].Trim(), headerParts[1].Trim()));
+            }
+        }
+
+        var mockResponse = new MockResponse
+        {
+            Request = new()
+            {
+                Url = "*"
+            },
+            Response = new()
+            {
+                StatusCode = statusCode,
+                Headers = responseHeaders,
+                Body = body
+            }
+        };
+
+        logger.LogTrace("Left {Method}", nameof(FromHttpResponse));
+
+        return mockResponse;
     }
 }
 

--- a/DevProxy.Plugins/DevProxy.Plugins.csproj
+++ b/DevProxy.Plugins/DevProxy.Plugins.csproj
@@ -28,6 +28,10 @@
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.6">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.8.0">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/DevProxy.Plugins/packages.lock.json
+++ b/DevProxy.Plugins/packages.lock.json
@@ -41,6 +41,12 @@
           "Microsoft.Extensions.Primitives": "9.0.4"
         }
       },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Direct",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "1HJCAbwukNEoYbHgHbKHmenU0V/0huw8+i7Qtf5rLUG1E+3kEwRJQxpwD3wbTEagIgPSQisNgJTvmUX9yYVc6g=="
+      },
       "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
         "type": "Direct",
         "requested": "[8.8.0, )",
@@ -303,11 +309,6 @@
           "Microsoft.Extensions.FileSystemGlobbing": "9.0.4",
           "Microsoft.Extensions.Primitives": "9.0.4"
         }
-      },
-      "Microsoft.Extensions.FileSystemGlobbing": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "05Lh2ItSk4mzTdDWATW9nEcSybwprN8Tz42Fs5B+jwdXUpauktdAQUI1Am4sUQi2C63E5hvQp8gXvfwfg9mQGQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",

--- a/DevProxy/DevProxy.csproj
+++ b/DevProxy/DevProxy.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="9.0.6" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.4" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.8.0" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.24" />

--- a/DevProxy/packages.lock.json
+++ b/DevProxy/packages.lock.json
@@ -62,6 +62,12 @@
           "Microsoft.Extensions.FileProviders.Abstractions": "9.0.4"
         }
       },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Direct",
+        "requested": "[9.0.6, )",
+        "resolved": "9.0.6",
+        "contentHash": "1HJCAbwukNEoYbHgHbKHmenU0V/0huw8+i7Qtf5rLUG1E+3kEwRJQxpwD3wbTEagIgPSQisNgJTvmUX9yYVc6g=="
+      },
       "Microsoft.Extensions.Logging.Console": {
         "type": "Direct",
         "requested": "[9.0.4, )",
@@ -350,11 +356,6 @@
           "Microsoft.Extensions.FileSystemGlobbing": "9.0.4",
           "Microsoft.Extensions.Primitives": "9.0.4"
         }
-      },
-      "Microsoft.Extensions.FileSystemGlobbing": {
-        "type": "Transitive",
-        "resolved": "9.0.4",
-        "contentHash": "05Lh2ItSk4mzTdDWATW9nEcSybwprN8Tz42Fs5B+jwdXUpauktdAQUI1Am4sUQi2C63E5hvQp8gXvfwfg9mQGQ=="
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",


### PR DESCRIPTION
Extends MockResponsePlugin with a command to generate mocks from HTTP responses. Closes #1261