### PR TITLE
Fixes logging from plugins' commands

### DIFF
--- a/DevProxy/Extensions/ILoggingBuilderExtensions.cs
+++ b/DevProxy/Extensions/ILoggingBuilderExtensions.cs
@@ -30,10 +30,9 @@ static class ILoggingBuilderExtensions
             .AddFilter("Microsoft.AspNetCore.*", LogLevel.Error)
             .AddFilter("Microsoft.Extensions.*", LogLevel.Error)
             .AddFilter("System.*", LogLevel.Error)
-            // Only show plugin messages for the root command
+            // Only show plugin messages when no global options are set
             .AddFilter("DevProxy.Plugins.*", level =>
                 level >= configuredLogLevel &&
-                DevProxyCommand.IsRootCommand &&
                 !DevProxyCommand.HasGlobalOptions)
             .AddConsole(options =>
                 {


### PR DESCRIPTION
Before this fix, if a plugin had a subcommand, the log messages wouldn't be displayed.