### PR TITLE
Makes the --log-level option globally available

### DIFF
--- a/DevProxy/Commands/DevProxyCommand.cs
+++ b/DevProxy/Commands/DevProxyCommand.cs
@@ -179,7 +179,8 @@ sealed class DevProxyCommand : RootCommand
         var logLevelOption = new Option<LogLevel?>(LogLevelOptionName)
         {
             Description = $"Level of messages to log. Allowed values: {string.Join(", ", Enum.GetNames<LogLevel>())}",
-            HelpName = "log-level"
+            HelpName = "log-level",
+            Recursive = true
         };
         logLevelOption.Validators.Add(input =>
         {


### PR DESCRIPTION
After upgrading to System.CommandLine beta5, we lost --log-level on commands but the root. This change fixes it.