### PR TITLE
Fixes issue with DevToolsPlugin not showing request headers

### DIFF
--- a/DevProxy.Plugins/Inspection/DevToolsPlugin.cs
+++ b/DevProxy.Plugins/Inspection/DevToolsPlugin.cs
@@ -185,7 +185,8 @@ public sealed class DevToolsPlugin(
                         .GroupBy(h => h.Name)
                         .ToDictionary(g => g.Key, g => string.Join(", ", g.Select(h => h.Value))),
                     MimeType = e.Session.HttpClient.Response.ContentType
-                }
+                },
+                HasExtraInfo = true
             }
         };
 


### PR DESCRIPTION
Prior to this fix, DevToolsPlugin would show a warning that it only shows "provisional headers" for the intercepted requests. This fix addresses this issue and makes Chrome Dev Tools show the actually intercepted request headers.