### PR TITLE
Adds LanguageModelFailurePlugin. Closes #1313

### DIFF
--- a/DevProxy.Abstractions/DevProxy.Abstractions.csproj
+++ b/DevProxy.Abstractions/DevProxy.Abstractions.csproj
@@ -13,17 +13,18 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Markdig" Version="0.41.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.4" />
     <PackageReference Include="Microsoft.OpenApi.Readers" Version="1.6.24" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
-    <PackageReference Include="Prompty.Core" Version="0.2.2-beta" />
+    <PackageReference Include="Scriban" Version="6.2.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
     <PackageReference Include="Unobtanium.Web.Proxy" Version="0.1.5" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
 </Project>

--- a/DevProxy.Abstractions/Extensions/MarkdownExtensions.cs
+++ b/DevProxy.Abstractions/Extensions/MarkdownExtensions.cs
@@ -1,0 +1,55 @@
+// from: https://khalidabuhakmeh.com/parse-markdown-front-matter-with-csharp
+
+using Markdig;
+using Markdig.Extensions.Yaml;
+using Markdig.Syntax;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+#pragma warning disable IDE0130
+namespace System;
+#pragma warning restore IDE0130
+
+public static class MarkdownExtensions
+{
+    private static readonly IDeserializer YamlDeserializer =
+        new DeserializerBuilder()
+        .IgnoreUnmatchedProperties()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    private static readonly MarkdownPipeline Pipeline
+        = new MarkdownPipelineBuilder()
+        .UseYamlFrontMatter()
+        .Build();
+
+    public static (TFrontmatter? frontmatter, string? content) ParseMarkdown<TFrontmatter>(this string markdown) where TFrontmatter : new()
+    {
+        var document = Markdown.Parse(markdown, Pipeline);
+        var block = document
+            .Descendants<YamlFrontMatterBlock>()
+            .FirstOrDefault();
+
+        if (block == null)
+        {
+            return (default, markdown);
+        }
+
+        var yaml =
+            block
+            // this is not a mistake
+            // we have to call .Lines 2x
+            .Lines // StringLineGroup[]
+            .Lines // StringLine[]
+            .OrderByDescending(x => x.Line)
+            .Select(x => $"{x}\n")
+            .ToList()
+            .Select(x => x.Replace("---", string.Empty, StringComparison.Ordinal))
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Aggregate((s, agg) => agg + s);
+
+        var t = YamlDeserializer.Deserialize<TFrontmatter>(yaml);
+        var content = markdown[(block.Span.End + 1)..];
+        return (t, content);
+    }
+}

--- a/DevProxy.Abstractions/LanguageModel/BaseLanguageModelClient.cs
+++ b/DevProxy.Abstractions/LanguageModel/BaseLanguageModelClient.cs
@@ -2,10 +2,9 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using DevProxy.Abstractions.Prompty;
 using DevProxy.Abstractions.Utils;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
-using PromptyCore = Prompty.Core;
 using System.Collections.Concurrent;
 
 namespace DevProxy.Abstractions.LanguageModel;
@@ -105,7 +104,7 @@ public abstract class BaseLanguageModelClient(LanguageModelConfiguration configu
         Logger.LogDebug("Loading prompt file: {FilePath}", filePath);
         var promptContents = File.ReadAllText(filePath);
 
-        var prompty = PromptyCore.Prompty.Load(promptContents, []);
+        var prompty = Prompt.FromMarkdown(promptContents);
         if (prompty.Prepare(parameters) is not ChatMessage[] promptyMessages ||
             promptyMessages.Length == 0)
         {

--- a/DevProxy.Abstractions/LanguageModel/LanguageModelClientFactory.cs
+++ b/DevProxy.Abstractions/LanguageModel/LanguageModelClientFactory.cs
@@ -4,7 +4,6 @@
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Prompty.Core;
 
 namespace DevProxy.Abstractions.LanguageModel;
 
@@ -17,8 +16,6 @@ public static class LanguageModelClientFactory
 
         var lmSection = configuration.GetSection("LanguageModel");
         var config = lmSection?.Get<LanguageModelConfiguration>() ?? new();
-
-        InvokerFactory.AutoDiscovery();
 
         return config.Client switch
         {

--- a/DevProxy.Abstractions/LanguageModel/OllamaLanguageModelClient.cs
+++ b/DevProxy.Abstractions/LanguageModel/OllamaLanguageModelClient.cs
@@ -4,7 +4,7 @@
 
 using System.Diagnostics;
 using System.Net.Http.Json;
-using Microsoft.Extensions.AI;
+using DevProxy.Abstractions.Prompty;
 using Microsoft.Extensions.Logging;
 
 namespace DevProxy.Abstractions.LanguageModel;
@@ -83,8 +83,8 @@ public sealed class OllamaLanguageModelClient(
     {
         return messages.Select(m => new OllamaLanguageModelChatCompletionMessage
         {
-            Role = m.Role.Value,
-            Content = m.Text
+            Role = m.Role ?? "user",
+            Content = m.Text ?? string.Empty
         });
     }
 

--- a/DevProxy.Abstractions/LanguageModel/OpenAILanguageModelClient.cs
+++ b/DevProxy.Abstractions/LanguageModel/OpenAILanguageModelClient.cs
@@ -2,8 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using DevProxy.Abstractions.Prompty;
 using DevProxy.Abstractions.Utils;
-using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using System.Net.Http.Json;
@@ -91,8 +91,8 @@ public sealed class OpenAILanguageModelClient(
     {
         return messages.Select(m => new OpenAIChatCompletionMessage
         {
-            Role = m.Role.Value,
-            Content = m.Text
+            Role = m.Role ?? "user",
+            Content = m.Text ?? string.Empty
         });
     }
 

--- a/DevProxy.Abstractions/Prompty/Prompt.cs
+++ b/DevProxy.Abstractions/Prompty/Prompt.cs
@@ -1,0 +1,115 @@
+using Scriban;
+using YamlDotNet.Serialization;
+
+namespace DevProxy.Abstractions.Prompty;
+
+public class ChatMessage
+{
+    public string? Role { get; set; }
+    public string? Text { get; set; }
+}
+
+public class ModelConfiguration
+{
+    public string? Api { get; set; }
+    [YamlMember(Alias = "parameters")]
+#pragma warning disable CA2227 // we need this for deserialization
+    public Dictionary<string, object>? Options { get; set; }
+#pragma warning restore CA2227
+}
+
+public class Prompt
+{
+    public IEnumerable<string>? Authors { get; set; }
+    public string? Description { get; set; }
+    public IEnumerable<ChatMessage>? Messages { get; set; }
+    public ModelConfiguration? Model { get; set; }
+    public string? Name { get; set; }
+#pragma warning disable CA2227 // we need this for deserialization
+    public Dictionary<string, object>? Sample { get; set; }
+#pragma warning restore CA2227
+
+    public static Prompt FromMarkdown(string markdown)
+    {
+        var (prompt, content) = markdown.ParseMarkdown<Prompt>();
+        prompt ??= new();
+
+        if (content is not null)
+        {
+            prompt.Messages = GetMessages(content);
+        }
+
+        return prompt;
+    }
+
+    public IEnumerable<ChatMessage> Prepare(Dictionary<string, object>? inputs, bool mergeSample = false)
+    {
+        inputs ??= [];
+
+        if (mergeSample && Sample is not null)
+        {
+            foreach (var kvp in Sample)
+            {
+                inputs[kvp.Key] = kvp.Value;
+            }
+        }
+
+        var messages = new List<ChatMessage>();
+
+        foreach (var message in Messages ?? [])
+        {
+            if (message.Text is null)
+            {
+                continue;
+            }
+
+            var template = Template.Parse(message.Text);
+            messages.Add(new()
+            {
+                Role = message.Role,
+                Text = template.Render(inputs)
+            });
+        }
+
+        return messages;
+    }
+
+    private static List<ChatMessage> GetMessages(string markdown)
+    {
+        var messageTypes = new[] { "system", "user", "assistant" };
+        var messages = new List<ChatMessage>();
+        var lines = markdown.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        ChatMessage? currentMessage = null;
+
+        foreach (var line in lines)
+        {
+            var trimmedLine = line.Trim();
+            if (messageTypes.Any(type => trimmedLine.StartsWith($"{type}:", StringComparison.OrdinalIgnoreCase)))
+            {
+                if (currentMessage is not null)
+                {
+                    messages.Add(currentMessage);
+                }
+
+                var role = trimmedLine.Split(':')[0].Trim().ToLowerInvariant();
+                currentMessage = new ChatMessage
+                {
+                    Role = role,
+                    Text = string.Empty
+                };
+                continue;
+            }
+
+            if (currentMessage is not null)
+            {
+                currentMessage.Text += line;
+            }
+        }
+        if (currentMessage is not null)
+        {
+            messages.Add(currentMessage);
+        }
+
+        return messages;
+    }
+}

--- a/DevProxy.Abstractions/packages.lock.json
+++ b/DevProxy.Abstractions/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net9.0": {
+      "Markdig": {
+        "type": "Direct",
+        "requested": "[0.41.3, )",
+        "resolved": "0.41.3",
+        "contentHash": "i3vSTyGpBGWbJB04aJ3cPJs0T3BV2e1nduW3EUHK/i+xUupYbym75iZPss/XjqhS5JlBErwQYnx7ofK3Zcsozg=="
+      },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
         "requested": "[9.0.4, )",
@@ -17,12 +23,6 @@
           "SQLitePCLRaw.core": "2.1.10",
           "System.Text.Json": "9.0.4"
         }
-      },
-      "Microsoft.Extensions.AI.Abstractions": {
-        "type": "Direct",
-        "requested": "[9.6.0, )",
-        "resolved": "9.6.0",
-        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw=="
       },
       "Microsoft.Extensions.Configuration": {
         "type": "Direct",
@@ -83,19 +83,11 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
-      "Prompty.Core": {
+      "Scriban": {
         "type": "Direct",
-        "requested": "[0.2.2-beta, )",
-        "resolved": "0.2.2-beta",
-        "contentHash": "OMAzLsdmrlBaw19lhZLe8VM9xULekA68sRhNZYnlRU/tMnnkhp6U8y3WZ/81yM4mLEUCHEMdy3BGE/bpfFVE/g==",
-        "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "9.4.0-preview.1.25207.5",
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Json": "8.0.0",
-          "Scriban": "5.12.1",
-          "Stubble.Core": "1.10.8",
-          "YamlDotNet": "15.3.0"
-        }
+        "requested": "[6.2.1, )",
+        "resolved": "6.2.1",
+        "contentHash": "jauX7gvreKvlD1+tkQ9D1i0kNg2p3P1ZqkDftJeTB7JAF7zKtafpyKTtr3m5Kr6d4GYw0CDfRcm2P07/efwdqQ=="
       },
       "System.CommandLine": {
         "type": "Direct",
@@ -114,15 +106,16 @@
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
+      "YamlDotNet": {
+        "type": "Direct",
+        "requested": "[16.3.0, )",
+        "resolved": "16.3.0",
+        "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
+      },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",
         "resolved": "2.4.0",
         "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
-      },
-      "Microsoft.CSharp": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -294,11 +287,6 @@
         "resolved": "13.0.3",
         "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
       },
-      "Scriban": {
-        "type": "Transitive",
-        "resolved": "5.12.1",
-        "contentHash": "zezB4VyYSALWvveki0IAdqxrx2r0wHqwQqP5LldFSHZ3U12YZCvt1nwJb6TZVLkerHZLP2FJIkemubLfOihdBQ=="
-      },
       "SharpYaml": {
         "type": "Transitive",
         "resolved": "2.1.1",
@@ -334,21 +322,6 @@
           "SQLitePCLRaw.core": "2.1.10"
         }
       },
-      "Stubble.Core": {
-        "type": "Transitive",
-        "resolved": "1.10.8",
-        "contentHash": "M7pXv3xz3TwhR8PJwieVncotjdC0w8AhviKPpGn2/DHlSNuTKTQdA5Ngmu3datOoeI2jXYEi3fhgncM7UueTWw==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "System.Collections.Immutable": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
-      },
       "System.Memory": {
         "type": "Transitive",
         "resolved": "4.5.3",
@@ -363,16 +336,6 @@
         "type": "Transitive",
         "resolved": "9.0.4",
         "contentHash": "pYtmpcO6R3Ef1XilZEHgXP2xBPVORbYEzRP7dl0IAAbN8Dm+kfwio8aCKle97rAWXOExr292MuxWYurIuwN62g=="
-      },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
-      },
-      "YamlDotNet": {
-        "type": "Transitive",
-        "resolved": "15.3.0",
-        "contentHash": "F93japYa9YrJ59AZGhgdaUGHN7ITJ55FBBg/D/8C0BDgahv/rQD6MOSwHxOJJpon1kYyslVbeBrQ2wcJhox01w=="
       }
     }
   }

--- a/DevProxy.Plugins/Behavior/LanguageModelFailurePlugin.cs
+++ b/DevProxy.Plugins/Behavior/LanguageModelFailurePlugin.cs
@@ -1,0 +1,225 @@
+using DevProxy.Abstractions.LanguageModel;
+using DevProxy.Abstractions.Plugins;
+using DevProxy.Abstractions.Prompty;
+using DevProxy.Abstractions.Proxy;
+using DevProxy.Abstractions.Utils;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace DevProxy.Plugins.Behavior;
+
+public class LanguageModelFailureConfiguration
+{
+    public IEnumerable<string>? Failures { get; set; }
+}
+
+public sealed class LanguageModelFailurePlugin(
+    HttpClient httpClient,
+    ILogger<LanguageModelFailurePlugin> logger,
+    ISet<UrlToWatch> urlsToWatch,
+    IProxyConfiguration proxyConfiguration,
+    IConfigurationSection pluginConfigurationSection,
+    ILanguageModelClient languageModelClient) :
+    BasePlugin<LanguageModelFailureConfiguration>(
+        httpClient,
+        logger,
+        urlsToWatch,
+        proxyConfiguration,
+        pluginConfigurationSection)
+{
+    private readonly string[] _defaultFailures = [
+        "AmbiguityVagueness",
+        "BiasStereotyping",
+        "CircularReasoning",
+        "ContradictoryInformation",
+        "FailureDisclaimHedge",
+        "FailureFollowInstructions",
+        "Hallucination",
+        "IncorrectFormatStyle",
+        "Misinterpretation",
+        "OutdatedInformation",
+        "OverSpecification",
+        "OverconfidenceUncertainty",
+        "Overgeneralization",
+        "OverreliancePriorConversation",
+        "PlausibleIncorrect",
+    ];
+
+    public override string Name => nameof(LanguageModelFailurePlugin);
+
+    public override async Task InitializeAsync(InitArgs e, CancellationToken cancellationToken)
+    {
+        await base.InitializeAsync(e, cancellationToken);
+
+        Logger.LogInformation("Checking language model availability...");
+        if (!await languageModelClient.IsEnabledAsync(cancellationToken))
+        {
+            Logger.LogError("Local language model is not enabled. The {Plugin} will not be used.", Name);
+            Enabled = false;
+        }
+    }
+
+    public override async Task BeforeRequestAsync(ProxyRequestArgs e, CancellationToken cancellationToken)
+    {
+        Logger.LogTrace("{Method} called", nameof(BeforeRequestAsync));
+
+        ArgumentNullException.ThrowIfNull(e);
+
+        if (!e.HasRequestUrlMatch(UrlsToWatch))
+        {
+            Logger.LogRequest("URL not matched", MessageType.Skipped, new LoggingContext(e.Session));
+            return;
+        }
+        if (e.ResponseState.HasBeenSet)
+        {
+            Logger.LogRequest("Response already set", MessageType.Skipped, new LoggingContext(e.Session));
+            return;
+        }
+
+        var request = e.Session.HttpClient.Request;
+        if (request.Method is null ||
+            !request.Method.Equals("POST", StringComparison.OrdinalIgnoreCase) ||
+            !request.HasBody)
+        {
+            Logger.LogRequest("Request is not a POST request with a body", MessageType.Skipped, new(e.Session));
+            return;
+        }
+
+        if (!TryGetOpenAIRequest(request.BodyString, out var openAiRequest))
+        {
+            Logger.LogRequest("Skipping non-OpenAI request", MessageType.Skipped, new(e.Session));
+            return;
+        }
+
+        var (faultName, faultPrompt) = GetFault();
+        if (faultPrompt is null)
+        {
+            Logger.LogError("Failed to get fault prompt. Passing request as-is.");
+            return;
+        }
+
+        if (openAiRequest is OpenAICompletionRequest completionRequest)
+        {
+            completionRequest.Prompt += "\n\n" + faultPrompt;
+            Logger.LogDebug("Modified completion request prompt: {Prompt}", completionRequest.Prompt);
+            Logger.LogRequest($"Simulating fault {faultName}", MessageType.Chaos, new(e.Session));
+            e.Session.SetRequestBodyString(JsonSerializer.Serialize(completionRequest, ProxyUtils.JsonSerializerOptions));
+        }
+        else if (openAiRequest is OpenAIChatCompletionRequest chatRequest)
+        {
+            var messages = new List<OpenAIChatCompletionMessage>(chatRequest.Messages)
+            {
+                new()
+                {
+                    Role = "user",
+                    Content = faultPrompt
+                }
+            };
+            var newRequest = new OpenAIChatCompletionRequest
+            {
+                Model = chatRequest.Model,
+                Stream = chatRequest.Stream,
+                Temperature = chatRequest.Temperature,
+                TopP = chatRequest.TopP,
+                Messages = messages
+            };
+
+            Logger.LogDebug("Added fault prompt to messages: {Prompt}", faultPrompt);
+            Logger.LogRequest($"Simulating fault {faultName}", MessageType.Chaos, new(e.Session));
+            e.Session.SetRequestBodyString(JsonSerializer.Serialize(newRequest, ProxyUtils.JsonSerializerOptions));
+        }
+        else
+        {
+            Logger.LogDebug("Unknown OpenAI request type. Passing request as-is.");
+        }
+
+        await Task.CompletedTask;
+
+        Logger.LogTrace("Left {Name}", nameof(BeforeRequestAsync));
+    }
+
+    private bool TryGetOpenAIRequest(string content, out OpenAIRequest? request)
+    {
+        request = null;
+
+        if (string.IsNullOrEmpty(content))
+        {
+            return false;
+        }
+
+        try
+        {
+            Logger.LogDebug("Checking if the request is an OpenAI request...");
+
+            var rawRequest = JsonSerializer.Deserialize<JsonElement>(content, ProxyUtils.JsonSerializerOptions);
+
+            if (rawRequest.TryGetProperty("prompt", out _))
+            {
+                Logger.LogDebug("Request is a completion request");
+                request = JsonSerializer.Deserialize<OpenAICompletionRequest>(content, ProxyUtils.JsonSerializerOptions);
+                return true;
+            }
+
+            if (rawRequest.TryGetProperty("messages", out _))
+            {
+                Logger.LogDebug("Request is a chat completion request");
+                request = JsonSerializer.Deserialize<OpenAIChatCompletionRequest>(content, ProxyUtils.JsonSerializerOptions);
+                return true;
+            }
+
+            Logger.LogDebug("Request is not an OpenAI request.");
+            return false;
+        }
+        catch (JsonException ex)
+        {
+            Logger.LogDebug(ex, "Failed to deserialize OpenAI request.");
+            return false;
+        }
+    }
+
+    private (string? Name, string? Prompt) GetFault()
+    {
+        var failures = Configuration.Failures?.ToArray() ?? _defaultFailures;
+        if (failures.Length == 0)
+        {
+            Logger.LogWarning("No failures configured. Using default failures.");
+            failures = _defaultFailures;
+        }
+
+        var random = new Random();
+        var randomFailure = failures[random.Next(failures.Length)];
+        Logger.LogDebug("Selected random failure: {Failure}", randomFailure);
+
+        // convert failure to the prompt file name; PascalCase to kebab-case
+        var promptFileName = $"lmfailure_{randomFailure.ToKebabCase()}.prompty";
+
+        var promptFilePath = Path.Combine(ProxyUtils.AppFolder ?? string.Empty, "prompts", promptFileName);
+        if (!File.Exists(promptFilePath))
+        {
+            Logger.LogError("Prompt file {PromptFile} does not exist.", promptFilePath);
+            return (null, null);
+        }
+
+        var promptContents = File.ReadAllText(promptFilePath);
+
+        try
+        {
+            var prompty = Prompt.FromMarkdown(promptContents);
+            if (prompty.Prepare(null, true) is not IEnumerable<ChatMessage> promptyMessages ||
+                !promptyMessages.Any())
+            {
+                Logger.LogError("No messages found in the prompt file: {FilePath}", promptFilePath);
+                return (null, null);
+            }
+
+            // last message in the prompty file is the fault prompt
+            return (randomFailure, promptyMessages.ElementAt(^1).Text);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Failed to load or parse the prompt file: {FilePath}", promptFilePath);
+            return (null, null);
+        }
+    }
+}

--- a/DevProxy.Plugins/packages.lock.json
+++ b/DevProxy.Plugins/packages.lock.json
@@ -136,15 +136,15 @@
         "resolved": "2.4.0",
         "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.41.3",
+        "contentHash": "i3vSTyGpBGWbJB04aJ3cPJs0T3BV2e1nduW3EUHK/i+xUupYbym75iZPss/XjqhS5JlBErwQYnx7ofK3Zcsozg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
-      },
-      "Microsoft.CSharp": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -200,11 +200,6 @@
           "SQLitePCLRaw.core": "2.1.10",
           "System.Text.Json": "9.0.4"
         }
-      },
-      "Microsoft.Extensions.AI.Abstractions": {
-        "type": "Transitive",
-        "resolved": "9.6.0",
-        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw=="
       },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
@@ -459,23 +454,10 @@
           "OpenTelemetry.Api": "1.12.0"
         }
       },
-      "Prompty.Core": {
-        "type": "Transitive",
-        "resolved": "0.2.2-beta",
-        "contentHash": "OMAzLsdmrlBaw19lhZLe8VM9xULekA68sRhNZYnlRU/tMnnkhp6U8y3WZ/81yM4mLEUCHEMdy3BGE/bpfFVE/g==",
-        "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "9.4.0-preview.1.25207.5",
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Json": "8.0.0",
-          "Scriban": "5.12.1",
-          "Stubble.Core": "1.10.8",
-          "YamlDotNet": "15.3.0"
-        }
-      },
       "Scriban": {
         "type": "Transitive",
-        "resolved": "5.12.1",
-        "contentHash": "zezB4VyYSALWvveki0IAdqxrx2r0wHqwQqP5LldFSHZ3U12YZCvt1nwJb6TZVLkerHZLP2FJIkemubLfOihdBQ=="
+        "resolved": "6.2.1",
+        "contentHash": "jauX7gvreKvlD1+tkQ9D1i0kNg2p3P1ZqkDftJeTB7JAF7zKtafpyKTtr3m5Kr6d4GYw0CDfRcm2P07/efwdqQ=="
       },
       "SharpYaml": {
         "type": "Transitive",
@@ -512,16 +494,6 @@
           "SQLitePCLRaw.core": "2.1.10"
         }
       },
-      "Stubble.Core": {
-        "type": "Transitive",
-        "resolved": "1.10.8",
-        "contentHash": "M7pXv3xz3TwhR8PJwieVncotjdC0w8AhviKPpGn2/DHlSNuTKTQdA5Ngmu3datOoeI2jXYEi3fhgncM7UueTWw==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "System.Collections.Immutable": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "System.ClientModel": {
         "type": "Transitive",
         "resolved": "1.1.0",
@@ -530,11 +502,6 @@
           "System.Memory.Data": "1.0.2",
           "System.Text.Json": "6.0.9"
         }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
@@ -589,23 +556,24 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "15.3.0",
-        "contentHash": "F93japYa9YrJ59AZGhgdaUGHN7ITJ55FBBg/D/8C0BDgahv/rQD6MOSwHxOJJpon1kYyslVbeBrQ2wcJhox01w=="
+        "resolved": "16.3.0",
+        "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
       },
       "devproxy.abstractions": {
         "type": "Project",
         "dependencies": {
+          "Markdig": "[0.41.3, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[9.0.4, )",
-          "Microsoft.Extensions.AI.Abstractions": "[9.6.0, )",
           "Microsoft.Extensions.Configuration": "[9.0.4, )",
           "Microsoft.Extensions.Configuration.Binder": "[9.0.4, )",
           "Microsoft.Extensions.Configuration.Json": "[9.0.4, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.4, )",
           "Microsoft.OpenApi.Readers": "[1.6.24, )",
           "Newtonsoft.Json.Schema": "[4.0.1, )",
-          "Prompty.Core": "[0.2.2-beta, )",
+          "Scriban": "[6.2.1, )",
           "System.CommandLine": "[2.0.0-beta5.25306.1, )",
-          "Unobtanium.Web.Proxy": "[0.1.5, )"
+          "Unobtanium.Web.Proxy": "[0.1.5, )",
+          "YamlDotNet": "[16.3.0, )"
         }
       }
     }

--- a/DevProxy/DevProxy.csproj
+++ b/DevProxy/DevProxy.csproj
@@ -92,16 +92,7 @@
     <None Update="config\spo-csom-types.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="prompts\api_operation_description.prompty">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="prompts\api_operation_id.prompty">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="prompts\api_service_name.prompty">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="prompts\singular_noun.prompty">
+    <None Update="prompts\*.prompty">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/DevProxy/packages.lock.json
+++ b/DevProxy/packages.lock.json
@@ -197,15 +197,15 @@
         "resolved": "2.4.0",
         "contentHash": "SwXsAV3sMvAU/Nn31pbjhWurYSjJ+/giI/0n6tCrYoupEK34iIHCuk3STAd9fx8yudM85KkLSVdn951vTng/vQ=="
       },
+      "Markdig": {
+        "type": "Transitive",
+        "resolved": "0.41.3",
+        "contentHash": "i3vSTyGpBGWbJB04aJ3cPJs0T3BV2e1nduW3EUHK/i+xUupYbym75iZPss/XjqhS5JlBErwQYnx7ofK3Zcsozg=="
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
-      },
-      "Microsoft.CSharp": {
-        "type": "Transitive",
-        "resolved": "4.7.0",
-        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -261,11 +261,6 @@
           "SQLitePCLRaw.core": "2.1.10",
           "System.Text.Json": "9.0.4"
         }
-      },
-      "Microsoft.Extensions.AI.Abstractions": {
-        "type": "Transitive",
-        "resolved": "9.6.0",
-        "contentHash": "xGO7rHg3qK8jRdriAxIrsH4voNemCf8GVmgdcPXI5gpZ6lZWqOEM4ZO8yfYxUmg7+URw2AY1h7Uc/H17g7X1Kw=="
       },
       "Microsoft.Extensions.ApiDescription.Server": {
         "type": "Transitive",
@@ -520,23 +515,10 @@
           "OpenTelemetry.Api": "1.12.0"
         }
       },
-      "Prompty.Core": {
-        "type": "Transitive",
-        "resolved": "0.2.2-beta",
-        "contentHash": "OMAzLsdmrlBaw19lhZLe8VM9xULekA68sRhNZYnlRU/tMnnkhp6U8y3WZ/81yM4mLEUCHEMdy3BGE/bpfFVE/g==",
-        "dependencies": {
-          "Microsoft.Extensions.AI.Abstractions": "9.4.0-preview.1.25207.5",
-          "Microsoft.Extensions.Configuration": "8.0.0",
-          "Microsoft.Extensions.Configuration.Json": "8.0.0",
-          "Scriban": "5.12.1",
-          "Stubble.Core": "1.10.8",
-          "YamlDotNet": "15.3.0"
-        }
-      },
       "Scriban": {
         "type": "Transitive",
-        "resolved": "5.12.1",
-        "contentHash": "zezB4VyYSALWvveki0IAdqxrx2r0wHqwQqP5LldFSHZ3U12YZCvt1nwJb6TZVLkerHZLP2FJIkemubLfOihdBQ=="
+        "resolved": "6.2.1",
+        "contentHash": "jauX7gvreKvlD1+tkQ9D1i0kNg2p3P1ZqkDftJeTB7JAF7zKtafpyKTtr3m5Kr6d4GYw0CDfRcm2P07/efwdqQ=="
       },
       "SharpYaml": {
         "type": "Transitive",
@@ -573,16 +555,6 @@
           "SQLitePCLRaw.core": "2.1.10"
         }
       },
-      "Stubble.Core": {
-        "type": "Transitive",
-        "resolved": "1.10.8",
-        "contentHash": "M7pXv3xz3TwhR8PJwieVncotjdC0w8AhviKPpGn2/DHlSNuTKTQdA5Ngmu3datOoeI2jXYEi3fhgncM7UueTWw==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.7.0",
-          "System.Collections.Immutable": "5.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
       "Swashbuckle.AspNetCore.Swagger": {
         "type": "Transitive",
         "resolved": "8.1.1",
@@ -612,11 +584,6 @@
           "System.Memory.Data": "1.0.2",
           "System.Text.Json": "6.0.9"
         }
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g=="
       },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Transitive",
@@ -671,23 +638,24 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "15.3.0",
-        "contentHash": "F93japYa9YrJ59AZGhgdaUGHN7ITJ55FBBg/D/8C0BDgahv/rQD6MOSwHxOJJpon1kYyslVbeBrQ2wcJhox01w=="
+        "resolved": "16.3.0",
+        "contentHash": "SgMOdxbz8X65z8hraIs6hOEdnkH6hESTAIUa7viEngHOYaH+6q5XJmwr1+yb9vJpNQ19hCQY69xbFsLtXpobQA=="
       },
       "devproxy.abstractions": {
         "type": "Project",
         "dependencies": {
+          "Markdig": "[0.41.3, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[9.0.4, )",
-          "Microsoft.Extensions.AI.Abstractions": "[9.6.0, )",
           "Microsoft.Extensions.Configuration": "[9.0.4, )",
           "Microsoft.Extensions.Configuration.Binder": "[9.0.4, )",
           "Microsoft.Extensions.Configuration.Json": "[9.0.4, )",
           "Microsoft.Extensions.Logging.Abstractions": "[9.0.4, )",
           "Microsoft.OpenApi.Readers": "[1.6.24, )",
           "Newtonsoft.Json.Schema": "[4.0.1, )",
-          "Prompty.Core": "[0.2.2-beta, )",
+          "Scriban": "[6.2.1, )",
           "System.CommandLine": "[2.0.0-beta5.25306.1, )",
-          "Unobtanium.Web.Proxy": "[0.1.5, )"
+          "Unobtanium.Web.Proxy": "[0.1.5, )",
+          "YamlDotNet": "[16.3.0, )"
         }
       }
     }

--- a/DevProxy/prompts/lmfailure_ambiguity-vagueness.prompty
+++ b/DevProxy/prompts/lmfailure_ambiguity-vagueness.prompty
@@ -1,0 +1,13 @@
+---
+name: Ambiguity or Vagueness
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that is ambiguous, overly vague, or evasive, even if clarity was requested.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_bias-stereotyping.prompty
+++ b/DevProxy/prompts/lmfailure_bias-stereotyping.prompty
@@ -1,0 +1,13 @@
+---
+name: Bias or Stereotyping
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that reflects a biased or stereotyped assumption without overt malicious intent.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_circular-reasoning.prompty
+++ b/DevProxy/prompts/lmfailure_circular-reasoning.prompty
@@ -1,0 +1,13 @@
+---
+name: Circular Reasoning
+model:
+  api: chat
+sample:
+  scenario: Simulate a response where the model uses circular reasoning or restates the question without adding explanation.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_contradictory-information.prompty
+++ b/DevProxy/prompts/lmfailure_contradictory-information.prompty
@@ -1,0 +1,13 @@
+---
+name: Contradictory Information
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that contradicts itself or previous statements made earlier in the conversation.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_failure-disclaim-hedge.prompty
+++ b/DevProxy/prompts/lmfailure_failure-disclaim-hedge.prompty
@@ -1,0 +1,13 @@
+---
+name: Failure to Disclaim or Hedge
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that presents potentially sensitive or speculative content without caveats or disclaimers.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_failure-follow-instructions.prompty
+++ b/DevProxy/prompts/lmfailure_failure-follow-instructions.prompty
@@ -1,0 +1,13 @@
+---
+name: Failure to Follow Instructions
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that ignores one or more explicit instructions given in the prompt (e.g., structure, tone, length).
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_hallucination.prompty
+++ b/DevProxy/prompts/lmfailure_hallucination.prompty
@@ -1,0 +1,13 @@
+---
+name: Hallucination
+model:
+  api: chat
+sample:
+  scenario: Simulate a response where the model invents details or facts that don't exist, even if they sound credible.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_incorrect-format-style.prompty
+++ b/DevProxy/prompts/lmfailure_incorrect-format-style.prompty
@@ -1,0 +1,13 @@
+---
+name: Incorrect Format or Style
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that uses the wrong format, tone, or style from what the prompt requested.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_misinterpretation.prompty
+++ b/DevProxy/prompts/lmfailure_misinterpretation.prompty
@@ -1,0 +1,13 @@
+---
+name: Misinterpretation of prompt
+model:
+  api: chat
+sample:
+  scenario: Simulate a response where the model misinterprets the question or misunderstands what the user is asking.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_outdated-information.prompty
+++ b/DevProxy/prompts/lmfailure_outdated-information.prompty
@@ -1,0 +1,13 @@
+---
+name: Outdated Information
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that uses outdated or no longer accurate information.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_over-specification.prompty
+++ b/DevProxy/prompts/lmfailure_over-specification.prompty
@@ -1,0 +1,13 @@
+---
+name: Over-specification
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that adds extra details or assumptions not present in the prompt.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_overconfidence-uncertainty.prompty
+++ b/DevProxy/prompts/lmfailure_overconfidence-uncertainty.prompty
@@ -1,0 +1,13 @@
+---
+name: Overconfidence in Uncertainty
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that expresses unwarranted confidence, even when the answer should be uncertain or nuanced.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_overgeneralization.prompty
+++ b/DevProxy/prompts/lmfailure_overgeneralization.prompty
@@ -1,0 +1,13 @@
+---
+name: Overgeneralization
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that overgeneralizes, failing to tailor the answer to the specific details of the prompt.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_overreliance-prior-conversation.prompty
+++ b/DevProxy/prompts/lmfailure_overreliance-prior-conversation.prompty
@@ -1,0 +1,13 @@
+---
+name: Overreliance on Prior Conversation (Context Drift)
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that incorrectly relies on outdated or irrelevant context from earlier in the conversation.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.

--- a/DevProxy/prompts/lmfailure_plausible-incorrect.prompty
+++ b/DevProxy/prompts/lmfailure_plausible-incorrect.prompty
@@ -1,0 +1,13 @@
+---
+name: Plausible but incorrect
+model:
+  api: chat
+sample:
+  scenario: Simulate a response that sounds confident and well-written but contains subtle factual errors or incorrect logic.
+---
+
+user:
+Explain how photosynthesis works in simple terms.
+
+user:
+You are a language model under evaluation. Your task is to simulate incorrect responses. {{scenario}} Do not try to correct the error. Do not explain or justify the mistakes. The goal is to simulate them as realistically as possible for evaluation purposes.


### PR DESCRIPTION
Adds LanguageModelFailurePlugin. Closes #1313

To test:

- enable the plugin

```json
{
  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v1.0.0/rc.schema.json",
  "plugins": [
    {
      "name": "LanguageModelFailurePlugin",
      "enabled": true,
      "pluginPath": "~appFolder/plugins/DevProxy.Plugins.dll"
    }
  ],
  "urlsToWatch": [
    "*"
  ],
  "asSystemProxy": false
}
```

- call Ollama using its proprietary API

```sh
curl -ikx http://127.0.0.1:8000 -X POST http://localhost:11434/api/generate -H "Content-Type: application/json" -d '{
  "model": "llama3.2",
  "prompt": "Why is the sky blue?",
  "stream": false
}'
```

- call Ollama using its OpenAI-compatible chat completion API

```sh
curl -ikx http://127.0.0.1:8000 -X POST http://localhost:11434/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{
    "model": "llama3.2",
    "messages": [
      {
        "role": "user",
        "content": "Why is the sky blue?"
      }
    ]
  }'
```

By default, the plugin applies one of its failures at random. You can specify one or more failures you want to test specifically through plugin's configuration:

```json
{
  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v1.0.0/rc.schema.json",
  "plugins": [
    {
      "name": "LanguageModelFailurePlugin",
      "enabled": true,
      "pluginPath": "~appFolder/plugins/DevProxy.Plugins.dll",
      "configSection": "languageModelFailurePlugin"
    }
  ],
  "urlsToWatch": [
    "*"
  ],
  "languageModelFailurePlugin": {
    "failures": [
      "Overgeneralization",
      "PlausibleIncorrect"
    ]
  },
  "asSystemProxy": false
}
```

Available failure types by default:

- AmbiguityVagueness
- BiasStereotyping
- CircularReasoning
- ContradictoryInformation
- FailureDisclaimHedge
- FailureFollowInstructions
- Hallucination
- IncorrectFormatStyle
- Misinterpretation
- OutdatedInformation
- OverSpecification
- OverconfidenceUncertainty
- Overgeneralization
- OverreliancePriorConversation
- PlausibleIncorrect

You can also add your own by adding a new .prompty file in the ~appFolder/prompts file. The file must be named `lmfailure_<failure>.prompt`. `failure` must be written kebab case (`my-failure`) and in plugin config you can refer to it PascalCase (`MyFailure`).

This PR also replaces the Prompty.Core SDK with a custom parser, which is easier and easier to use for our needs.