### PR TITLE
Adds support for mirroring mock responses. Closes #1384

### DIFF
--- a/DevProxy.Plugins/Mocking/MockResponsePlugin.cs
+++ b/DevProxy.Plugins/Mocking/MockResponsePlugin.cs
@@ -374,6 +374,8 @@ public class MockResponsePlugin(
             ProxyUtils.MergeHeaders(headers, rateLimitingHeaders);
         }
 
+        ReplacePlaceholders(matchingResponse.Response, e.Session.HttpClient.Request, Logger);
+
         if (matchingResponse.Response?.Body is not null)
         {
             var bodyString = JsonSerializer.Serialize(matchingResponse.Response.Body, ProxyUtils.JsonSerializerOptions) as string;
@@ -513,5 +515,193 @@ public class MockResponsePlugin(
         }
 
         return request.BodyString.Contains(mockResponse.Request.BodyFragment, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void ReplacePlaceholders(MockResponseResponse? response, Request request, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(ReplacePlaceholders));
+
+        if (response is null ||
+            response.Body is null || request.BodyString is null)
+        {
+            logger.LogTrace("Body is empty. Skipping replacing placeholders");
+            return;
+        }
+
+        try
+        {
+            var requestBody = JsonSerializer.Deserialize<dynamic>(request.BodyString, ProxyUtils.JsonSerializerOptions);
+
+            response.Body = ReplacePlaceholdersInObject(response.Body, requestBody, logger);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "Failed to parse request body as JSON");
+            logger.LogWarning("Failed to parse request body as JSON. Placeholders in the mock response won't be replaced.");
+        }
+
+        logger.LogTrace("Left {Method}", nameof(ReplacePlaceholders));
+    }
+
+    private static object? ReplacePlaceholdersInObject(object? obj, dynamic requestBody, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(ReplacePlaceholdersInObject));
+
+        if (obj is null)
+        {
+            return null;
+        }
+
+        // Handle JsonElement (which is what we get from System.Text.Json)
+        if (obj is JsonElement element)
+        {
+            return ReplacePlaceholdersInJsonElement(element, requestBody, logger);
+        }
+
+        // Handle string values - check for placeholders
+        if (obj is string strValue)
+        {
+            return ReplacePlaceholderInString(strValue, requestBody, logger);
+        }
+
+        // For other types, convert to JsonElement and process
+        var json = JsonSerializer.Serialize(obj);
+        var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+        return ReplacePlaceholdersInJsonElement(jsonElement, requestBody, logger);
+    }
+
+    private static object? ReplacePlaceholdersInJsonElement(JsonElement element, dynamic requestBody, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(ReplacePlaceholdersInJsonElement));
+
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                var resultObj = new Dictionary<string, object?>();
+                foreach (var property in element.EnumerateObject())
+                {
+                    resultObj[property.Name] = ReplacePlaceholdersInJsonElement(property.Value, requestBody, logger);
+                }
+                return resultObj;
+
+            case JsonValueKind.Array:
+                var resultArray = new List<object?>();
+                foreach (var item in element.EnumerateArray())
+                {
+                    resultArray.Add(ReplacePlaceholdersInJsonElement(item, requestBody, logger));
+                }
+                return resultArray;
+            case JsonValueKind.String:
+                return ReplacePlaceholderInString(element.GetString() ?? "", requestBody, logger);
+            case JsonValueKind.Number:
+                return element.GetDecimal();
+            case JsonValueKind.True:
+                return true;
+            case JsonValueKind.False:
+                return false;
+            case JsonValueKind.Null:
+            case JsonValueKind.Undefined:
+                return null;
+            default:
+                return element.ToString();
+        }
+    }
+
+#pragma warning disable CA1859 // Return type must be object because we can return any type from the request
+    private static object? ReplacePlaceholderInString(string value, dynamic requestBody, ILogger logger)
+#pragma warning restore CA1859
+    {
+        logger.LogTrace("{Method} called", nameof(ReplacePlaceholderInString));
+
+        logger.LogDebug("Processing value: {Value}", value);
+
+        // Check if the value starts with @request.body.
+        if (!value.StartsWith("@request.body.", StringComparison.OrdinalIgnoreCase))
+        {
+            logger.LogDebug("Value {Value} does not start with @request.body. Skipping", value);
+            return value;
+        }
+
+        // Extract the property path after @request.body.
+        var propertyPath = value["@request.body.".Length..];
+
+        logger.LogDebug("Extracted property path: {PropertyPath}", propertyPath);
+
+        return GetValueFromRequestBody(requestBody, propertyPath, logger);
+    }
+
+    private static object? GetValueFromRequestBody(dynamic requestBody, string propertyPath, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(GetValueFromRequestBody));
+
+        logger.LogDebug("Getting value for {PropertyPath}", propertyPath);
+
+        try
+        {
+            // Split the property path by dots to handle nested properties
+            var propertyNames = propertyPath.Split('.');
+
+            // Handle JsonElement
+            if (requestBody is JsonElement element)
+            {
+                return GetNestedValueFromJsonElement(element, propertyNames, logger);
+            }
+            else
+            {
+                // Handle other dynamic types by converting to JsonElement
+                var json = JsonSerializer.Serialize(requestBody);
+                var jsonElement = JsonSerializer.Deserialize<JsonElement>(json);
+                return GetNestedValueFromJsonElement(jsonElement, propertyNames, logger);
+            }
+        }
+        catch
+        {
+            // If we can't get the property, return null
+        }
+
+        return null;
+    }
+
+    private static object? GetNestedValueFromJsonElement(JsonElement element, string[] propertyNames, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(GetNestedValueFromJsonElement));
+
+        var current = element;
+
+        // Navigate through the nested properties
+        foreach (var propertyName in propertyNames)
+        {
+            if (current.ValueKind != JsonValueKind.Object)
+            {
+                logger.LogDebug("Current JSON element is not an object. Cannot navigate to property {PropertyName}", propertyName);
+                return null; // Can't navigate further if current element is not an object
+            }
+
+            if (!current.TryGetProperty(propertyName, out current))
+            {
+                logger.LogDebug("Property {PropertyName} not found in JSON. Returning null", propertyName);
+                return null; // Property not found
+            }
+        }
+
+        return ConvertJsonElementToObject(current, logger);
+    }
+
+    private static object? ConvertJsonElementToObject(JsonElement element, ILogger logger)
+    {
+        logger.LogTrace("{Method} called", nameof(ConvertJsonElementToObject));
+
+        return element.ValueKind switch
+        {
+            JsonValueKind.String => element.GetString(),
+            JsonValueKind.Number => element.GetDecimal(),
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            JsonValueKind.Null or JsonValueKind.Undefined => null,
+            // For complex objects/arrays, return the JsonElement itself
+            // which can be serialized later
+            JsonValueKind.Object or JsonValueKind.Array => element,
+            _ => element.ToString(),
+        };
     }
 }


### PR DESCRIPTION
Adds support for mirroring mock responses. Closes #1384

Test:

devproxyrc.json

```json
{
  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v1.1.0/rc.schema.json",
  "plugins": [
    {
      "name": "GraphMockResponsePlugin",
      "enabled": true,
      "pluginPath": "~appFolder/plugins/DevProxy.Plugins.dll",
      "configSection": "mocksPlugin"
    }
  ],
  "urlsToWatch": [
    "https://graph.microsoft.com/v1.0/users*"
  ],
  "mocksPlugin": {
    "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v1.1.0/mockresponseplugin.schema.json",
    "mocksFile": "mocks.json"
  },
  "asSystemProxy": false
}
```

mocks.json

```json
{
  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v1.1.0/mockresponseplugin.mocksfile.schema.json",
  "mocks": [
    {
      "request": {
        "url": "https://graph.microsoft.com/v1.0/users",
        "method": "POST"
      },
      "response": {
        "statusCode": 201,
        "body": {
          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
          "id": "12345678-1234-1234-1234-123456789abc",
          "businessPhones": "@request.body.businessPhones",
          "displayName": "@request.body.displayName",
          "givenName": "@request.body.givenName",
          "jobTitle": "@request.body.jobTitle",
          "mail": "@request.body.mail",
          "mobilePhone": "@request.body.mobilePhone",
          "officeLocation": "@request.body.officeLocation",
          "preferredLanguage": "@request.body.preferredLanguage",
          "surname": "@request.body.surname",
          "userPrincipalName": "@request.body.userPrincipalName",
          "accountEnabled": "@request.body.accountEnabled",
          "createdDateTime": "2024-01-15T10:30:00Z",
          "department": "@request.body.department",
          "companyName": "@request.body.companyName",
          "city": "@request.body.city",
          "country": "@request.body.country",
          "postalCode": "@request.body.postalCode",
          "state": "@request.body.state",
          "streetAddress": "@request.body.streetAddress",
          "usageLocation": "@request.body.usageLocation"
        },
        "headers": [
          {
            "name": "Content-Type",
            "value": "application/json; odata.metadata=minimal"
          },
          {
            "name": "Location",
            "value": "https://graph.microsoft.com/v1.0/users/12345678-1234-1234-1234-123456789abc"
          },
          {
            "name": "OData-Version",
            "value": "4.0"
          }
        ]
      }
    }
  ]
}
```

curl:

```sh
ccurl -ikx http://127.0.0.1:8000 -X POST https://graph.microsoft.com/v1.0/users \
  -H "Content-Type: application/json" \
  -d '{
    "displayName": "Jane Smith",
    "userPrincipalName": "jane.smith@contoso.com",
    "accountEnabled": true,
    "givenName": "Jane",
    "surname": "Smith",
    "jobTitle": "Product Manager"
  }'
```

response:

```text
HTTP/1.1 200 Connection Established
Content-Length: 0

HTTP/1.1 201 Created
Cache-Control: no-store
x-ms-ags-diagnostic: 
Strict-Transport-Security: 
request-id: d28ce889-febd-4c2b-a8b7-0a83e2531467
client-request-id: d28ce889-febd-4c2b-a8b7-0a83e2531467
Date: 9/10/2025 10:28:35?AM
Content-Type: application/json; odata.metadata=minimal
Location: https://graph.microsoft.com/v1.0/users/12345678-1234-1234-1234-123456789abc
OData-Version: 4.0
Content-Length: 648

{
  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
  "id": "12345678-1234-1234-1234-123456789abc",
  "businessPhones": null,
  "displayName": "Jane Smith",
  "givenName": "Jane",
  "jobTitle": "Product Manager",
  "mail": null,
  "mobilePhone": null,
  "officeLocation": null,
  "preferredLanguage": null,
  "surname": "Smith",
  "userPrincipalName": "jane.smith@contoso.com",
  "accountEnabled": true,
  "createdDateTime": "2024-01-15T10:30:00Z",
  "department": null,
  "companyName": null,
  "city": null,
  "country": null,
  "postalCode": null,
  "state": null,
  "streetAddress": null,
  "usageLocation": null
}
```