### PR TITLE
Fix BodyNotFoundException in MockResponsePlugin

### DIFF
--- a/DevProxy.Plugins/Mocking/MockResponsePlugin.cs
+++ b/DevProxy.Plugins/Mocking/MockResponsePlugin.cs
@@ -522,7 +522,7 @@ public class MockResponsePlugin(
         logger.LogTrace("{Method} called", nameof(ReplacePlaceholders));
 
         if (response is null ||
-            response.Body is null || request.BodyString is null)
+            response.Body is null || !request.HasBody)
         {
             logger.LogTrace("Body is empty. Skipping replacing placeholders");
             return;


### PR DESCRIPTION
# Description
In version 1.2.0 when configuring the MockResponsePlugin, it is not possible to return a mocked response for a GET request (or any request without a body). 

# Steps to reproduce
Use a mock.json example from https://learn.microsoft.com/en-us/microsoft-cloud/dev/dev-proxy/how-to/mock-responses. For example: 

```
{
  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v1.0.0/mockresponseplugin.mocksfile.schema.json",
  "mocks": [
    {
      "request": {
        "url": "https://graph.microsoft.com/v1.0/users/*"
      },
      "response": {
        "body": {
          "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
          "businessPhones": ["+1 425 555 0109"],
          "displayName": "Adele Vance",
          "givenName": "Adele",
          "jobTitle": "Product Marketing Manager",
          "mail": "AdeleV@M365x214355.onmicrosoft.com",
          "mobilePhone": null,
          "officeLocation": "18/2111",
          "preferredLanguage": "en-US",
          "surname": "Vance",
          "userPrincipalName": "AdeleV@M365x214355.onmicrosoft.com",
          "id": "87d349ed-44d7-43e1-9a83-5f2406dee5bd"
        }
      }
    }
  ]
}
``` 

Sending a request to this configured URL with "curl" causes the plugin to fail to process the request and just pass the request to the actual host.

```
 req   ╭ GET https://graph.microsoft.com/v1.0/users/exampleupn
 time  │ 10/6/2025 1:07:58 PM +00:00
 trce  │ MockResponsePlugin: BeforeRequestAsync called
 trce  │ MockResponsePlugin: ReplacePlaceholders called
 fail  │ An error occurred in a plugin
 pass  ╰ Passed through
```

# Issue
This is caused by an  `Titanium.Web.Proxy.Exceptions.BodyNotFoundException` in the first if-statement in the `ReplacePlaceholders` method of the MockResponsePlugin class, when trying to read the property `BodyString` on the request object.

# Fix
To prevent processing a body that is not present, the condition that causes the exception can be replaced with `!response.HasBody`, as it semantically means the same.

