### PR TITLE
fix: simplify YAML anchor pattern in devproxy-errors.yaml

### DIFF
--- a/DevProxy/devproxy-errors.yaml
+++ b/DevProxy/devproxy-errors.yaml
@@ -4,12 +4,11 @@
 # It demonstrates YAML features like comments, multiline strings, and anchors.
 
 # Define reusable error body templates using YAML anchors
-definitions:
-  client_error_body: &client_error_body
-    message: "Client Error"
+client_error_body: &client_error_body
+  message: "Client Error"
 
-  server_error_body: &server_error_body
-    message: "Server Error"
+server_error_body: &server_error_body
+  message: "Server Error"
 
 errors:
   - request:


### PR DESCRIPTION
## Summary

Removes the unnecessary `definitions:` wrapper from `devproxy-errors.yaml` and promotes YAML anchors to top-level keys.

YAML anchors are a native language feature and don't need a JSON Schema/OpenAPI-style container. The schema already allows arbitrary top-level keys, so no schema changes are needed.

### Before
```yaml
definitions:
  client_error_body: &client_error_body
    message: "Client Error"
  server_error_body: &server_error_body
    message: "Server Error"
```

### After
```yaml
client_error_body: &client_error_body
  message: "Client Error"

server_error_body: &server_error_body
  message: "Server Error"
```

Closes #1568