### PR TITLE
fix: decode response body as UTF-8 when no charset specified in DevToolsPlugin

### DIFF
--- a/DevProxy.Plugins/Inspection/DevToolsPlugin.cs
+++ b/DevProxy.Plugins/Inspection/DevToolsPlugin.cs
@@ -1069,15 +1069,21 @@ public sealed class DevToolsPlugin(
     // (RFC 7231, RFC 8259) treat UTF-8 as the default for JSON and most web content.
     private static string GetBodyString(string? contentType, byte[] body)
     {
-        if (contentType is not null &&
-            contentType.IndexOf("charset=", StringComparison.OrdinalIgnoreCase) > -1)
+        if (contentType is not null)
         {
-            // Charset is explicitly specified; decode the body using that charset
-            return Encoding.GetEncoding(
-                contentType[(contentType.IndexOf("charset=", StringComparison.OrdinalIgnoreCase) + 8)..]
-                    .Split(';', ' ')[0]
-                    .Trim()
-            ).GetString(body);
+            try
+            {
+                var ct = new System.Net.Mime.ContentType(contentType);
+                if (!string.IsNullOrEmpty(ct.CharSet))
+                {
+                    return Encoding.GetEncoding(ct.CharSet).GetString(body);
+                }
+            }
+            catch
+            {
+                // Malformed Content-Type or unsupported charset; fall through
+                // to UTF-8 default
+            }
         }
 
         return Encoding.UTF8.GetString(body);


### PR DESCRIPTION
## Summary

When the `Content-Type` header doesn't include a charset (e.g. `application/json` instead of `application/json; charset=utf-8`), the underlying proxy library defaults to ISO-8859-1 per the obsolete RFC 2616. This causes Unicode characters (e.g. ``) to appear garbled in the DevTools inspector.

## Fix

Default to UTF-8 when no charset is specified in the `Content-Type` header, aligning with modern standards:
- **RFC 7231 (2014):** Removed the ISO-8859-1 default from HTTP/1.1
- **RFC 8259 (2017):** JSON MUST be encoded as UTF-8

When a charset _is_ explicitly specified, we honor it.

## Changes

- Added `GetBodyString` helper that decodes raw response bytes using UTF-8 when no charset is present, or uses the specified charset otherwise
- Applied to both request body (`PostData`) and response body in DevToolsPlugin

Fixes #1566