### PR TITLE
Fix case-sensitive JWT claim filtering bypass

### DIFF
--- a/DevProxy/Jwt/JwtIssuer.cs
+++ b/DevProxy/Jwt/JwtIssuer.cs
@@ -37,19 +37,24 @@ internal sealed class JwtIssuer(string issuer, byte[] signingKeyMaterial)
 
         if (options.Claims is { Count: > 0 } claimsToAdd)
         {
-            // filter out registered claims
-            // https://www.rfc-editor.org/rfc/rfc7519#section-4.1            
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Iss);
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Sub);
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Aud);
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Exp);
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Nbf);
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Iat);
-            _ = claimsToAdd.Remove(JwtRegisteredClaimNames.Jti);
-            _ = claimsToAdd.Remove("scp");
-            _ = claimsToAdd.Remove("roles");
+            // filter out registered claims using case-insensitive comparison
+            // https://www.rfc-editor.org/rfc/rfc7519#section-4.1
+            var restrictedClaims = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                JwtRegisteredClaimNames.Iss,
+                JwtRegisteredClaimNames.Sub,
+                JwtRegisteredClaimNames.Aud,
+                JwtRegisteredClaimNames.Exp,
+                JwtRegisteredClaimNames.Nbf,
+                JwtRegisteredClaimNames.Iat,
+                JwtRegisteredClaimNames.Jti,
+                "scp",
+                "roles"
+            };
 
-            identity.AddClaims(claimsToAdd.Select(kvp => new Claim(kvp.Key, kvp.Value)));
+            identity.AddClaims(claimsToAdd
+                .Where(kvp => !restrictedClaims.Contains(kvp.Key))
+                .Select(kvp => new Claim(kvp.Key, kvp.Value)));
         }
 
         // Although the JwtPayload supports having multiple audiences registered, the


### PR DESCRIPTION
## Summary

Fixes a security bypass in `JwtIssuer.CreateSecurityToken` where restricted JWT claims could be injected using mixed-case keys (e.g. `SCP`, `ROLES`) because `Dictionary.Remove()` uses case-sensitive matching by default.

## Problem

The claim filtering logic used case-sensitive `Remove()` calls:

```csharp
_ = claimsToAdd.Remove("scp");
_ = claimsToAdd.Remove("roles");
```

An attacker could bypass this by passing `--claims "SCP:admin"` or `--claims "ROLES:SuperUser"`, resulting in a signed token containing elevated privileges.

## Fix

Replace the mutable `Remove()` approach with a `HashSet<string>(StringComparer.OrdinalIgnoreCase)` containing all restricted claim names, then filter claims via `.Where()` before adding them to the identity. This:

1. Blocks restricted claims regardless of casing
2. Avoids mutating the input dictionary as a side effect