### PR TITLE
Fix crash when multiple plugins register the same command

### DIFF
--- a/DevProxy/Commands/DevProxyCommand.cs
+++ b/DevProxy/Commands/DevProxyCommand.cs
@@ -606,7 +606,18 @@ sealed class DevProxyCommand : RootCommand
             ActivatorUtilities.CreateInstance<StopCommand>(_serviceProvider),
             ActivatorUtilities.CreateInstance<LogsCommand>(_serviceProvider)
         };
-        commands.AddRange(_plugins.SelectMany(p => p.GetCommands()));
+        var pluginCommands = _plugins.SelectMany(p => p.GetCommands());
+        foreach (var group in pluginCommands.GroupBy(c => c.Name))
+        {
+            var command = group.First();
+            commands.Add(command);
+            if (group.Count() > 1)
+            {
+                _logger.LogWarning(
+                    "Multiple plugins register the '{CommandName}' command. Only the first registration will be used",
+                    command.Name);
+            }
+        }
         this.AddCommands(commands.OrderByName());
 
         HelpExamples.Add(this, [


### PR DESCRIPTION
## Summary

Fixes the `ArgumentException: An item with the same key has already been added. Key: mocks` crash when using `EntraMockResponsePlugin` and `MockResponsePlugin` together, or multiple instances of `MockResponsePlugin`.

## Root cause

`EntraMockResponsePlugin` inherits from `MockResponsePlugin`, which registers a `"mocks"` command via `GetCommands()`. When both plugins are loaded, two `"mocks"` commands are registered, causing `System.CommandLine` to throw. The same crash occurs with two `MockResponsePlugin` instances using different config sections.

This is a regression introduced in v1.1.0 when `GetCommands()` was added to `MockResponsePlugin` (PR #1262).

## Fix

Deduplicate plugin commands by name before registering them — matching the existing approach for options (line 589-593). When duplicates are found, the first registration wins and a warning is logged so users and plugin authors aren't left guessing.

Closes #1690