### PR TITLE
fix: skip proxy-only plugin initialization for CLI subcommands

### DIFF
--- a/DevProxy.Abstractions/Proxy/ProxyEvents.cs
+++ b/DevProxy.Abstractions/Proxy/ProxyEvents.cs
@@ -45,6 +45,13 @@ public class ProxyResponseArgs(SessionEventArgs session, ResponseState responseS
 public class InitArgs
 {
     public required IServiceProvider ServiceProvider { get; init; }
+    /// <summary>
+    /// Indicates whether the proxy command (root command) is being invoked.
+    /// When false, a CLI subcommand is being executed and plugins should
+    /// skip initialization that is only relevant for proxy operation
+    /// (e.g., opening browsers, starting listeners).
+    /// </summary>
+    public bool IsProxyCommand { get; init; } = true;
 }
 
 public class OptionsLoadedArgs(ParseResult parseResult)

--- a/DevProxy.Plugins/Inspection/DevToolsPlugin.cs
+++ b/DevProxy.Plugins/Inspection/DevToolsPlugin.cs
@@ -79,9 +79,16 @@ public sealed class DevToolsPlugin(
 
     public override async Task InitializeAsync(InitArgs e, CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(e);
+
         _cancellationToken = cancellationToken;
 
         await base.InitializeAsync(e, cancellationToken);
+
+        if (!e.IsProxyCommand)
+        {
+            return;
+        }
 
         InitInspector();
     }

--- a/DevProxy.Plugins/Inspection/OpenAITelemetryPlugin.cs
+++ b/DevProxy.Plugins/Inspection/OpenAITelemetryPlugin.cs
@@ -76,6 +76,11 @@ public sealed class OpenAITelemetryPlugin(
 
         await base.InitializeAsync(e, cancellationToken);
 
+        if (!e.IsProxyCommand)
+        {
+            return;
+        }
+
         if (Configuration.IncludeCosts)
         {
             Configuration.PricesFile = ProxyUtils.GetFullPath(Configuration.PricesFile, ProxyConfiguration.ConfigFile);

--- a/DevProxy/Plugins/PluginServiceExtensions.cs
+++ b/DevProxy/Plugins/PluginServiceExtensions.cs
@@ -181,7 +181,7 @@ static class PluginServiceExtensions
                 // stage is synchronous, but if the implementation changes
                 // in the future then we won't need to change the interface
 #pragma warning disable VSTHRD002
-                plugin.InitializeAsync(new() { ServiceProvider = sp }, CancellationToken.None).Wait();
+                plugin.InitializeAsync(new() { ServiceProvider = sp, IsProxyCommand = DevProxyCommand.IsRootCommand }, CancellationToken.None).Wait();
 #pragma warning restore VSTHRD002
                 return plugin;
             });
@@ -200,7 +200,7 @@ static class PluginServiceExtensions
             // stage is synchronous, but if the implementation changes
             // in the future then we won't need to change the interface
 #pragma warning disable VSTHRD002
-            plugin.InitializeAsync(new() { ServiceProvider = sp }, CancellationToken.None).Wait();
+            plugin.InitializeAsync(new() { ServiceProvider = sp, IsProxyCommand = DevProxyCommand.IsRootCommand }, CancellationToken.None).Wait();
 #pragma warning restore VSTHRD002
             return plugin;
         });


### PR DESCRIPTION
## Summary

Fixes dotnet/dev-proxy#1722

When running CLI subcommands (e.g., `devproxy jwt create`), plugins like `DevToolsPlugin` would still fully initialize — opening a browser window. This PR adds an `IsProxyCommand` property to `InitArgs` so plugins can skip initialization that is only relevant when the proxy is actually running.

## Changes

- **`DevProxy.Abstractions/Proxy/ProxyEvents.cs`** — Added `IsProxyCommand` to `InitArgs` (defaults to `true` for backwards compatibility)
- **`DevProxy/Plugins/PluginServiceExtensions.cs`** — Passes `DevProxyCommand.IsRootCommand` when constructing `InitArgs`
- **`DevProxy.Plugins/Inspection/DevToolsPlugin.cs`** — Skips browser initialization when not the proxy command
- **`DevProxy.Plugins/Inspection/OpenAITelemetryPlugin.cs`** — Skips OTLP exporter/file watcher initialization when not the proxy command

## Backwards compatibility

`IsProxyCommand` defaults to `true`, so existing external plugins continue to work unchanged.