### PR TITLE
chore: bump NuGet dependencies

### DIFF
--- a/DevProxy.Abstractions/DevProxy.Abstractions.csproj
+++ b/DevProxy.Abstractions/DevProxy.Abstractions.csproj
@@ -45,7 +45,7 @@
     <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.9" />
     <PackageReference Include="Unobtanium.Web.Proxy" Version="0.1.5" />
-    <PackageReference Include="YamlDotNet" Version="18.0.0" />
+    <PackageReference Include="YamlDotNet" Version="18.1.0" />
   </ItemGroup>
 
 </Project>

--- a/DevProxy.Abstractions/packages.lock.json
+++ b/DevProxy.Abstractions/packages.lock.json
@@ -119,9 +119,9 @@
       },
       "YamlDotNet": {
         "type": "Direct",
-        "requested": "[18.0.0, )",
-        "resolved": "18.0.0",
-        "contentHash": "ptHVgcYmLejGuWXV7RMFoEqFKYMXnieOlWLPzEslfDtzZ9ngMhjYwykfqjBN2+fMEAEyobozkj07lKEpR4dssA=="
+        "requested": "[18.1.0, )",
+        "resolved": "18.1.0",
+        "contentHash": "5K+9KFg2TdTl7VXv88Qzi/0lqK6JFoNP3lRuImPYGRV7K/QYklDyTrj4+A+KAki1JsQi6qKY+hDyY7d6WRqjrw=="
       },
       "BouncyCastle.Cryptography": {
         "type": "Transitive",

--- a/DevProxy.Plugins/packages.lock.json
+++ b/DevProxy.Plugins/packages.lock.json
@@ -522,8 +522,8 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "ptHVgcYmLejGuWXV7RMFoEqFKYMXnieOlWLPzEslfDtzZ9ngMhjYwykfqjBN2+fMEAEyobozkj07lKEpR4dssA=="
+        "resolved": "18.1.0",
+        "contentHash": "5K+9KFg2TdTl7VXv88Qzi/0lqK6JFoNP3lRuImPYGRV7K/QYklDyTrj4+A+KAki1JsQi6qKY+hDyY7d6WRqjrw=="
       },
       "devproxy.abstractions": {
         "type": "Project",
@@ -541,7 +541,7 @@
           "Scriban": "[7.2.5, )",
           "System.CommandLine": "[2.0.9, )",
           "Unobtanium.Web.Proxy": "[0.1.5, )",
-          "YamlDotNet": "[18.0.0, )"
+          "YamlDotNet": "[18.1.0, )"
         }
       }
     }

--- a/DevProxy/DevProxy.csproj
+++ b/DevProxy/DevProxy.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="17.14.15" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="18.7.23" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OpenTelemetry" Version="1.16.0" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />

--- a/DevProxy/Proxy/CertificateDiskCache.cs
+++ b/DevProxy/Proxy/CertificateDiskCache.cs
@@ -18,10 +18,10 @@ internal sealed class CertificateDiskCache : ICertificateCache
 
     private string? rootCertificatePath;
 
-    public Task<X509Certificate2?> LoadRootCertificateAsync(string pathOrName, string password, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
+    public async Task<X509Certificate2?> LoadRootCertificateAsync(string pathOrName, string password, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
     {
         var path = GetRootCertificatePath(pathOrName, false);
-        return Task.FromResult(LoadCertificate(path, password, storageFlags));
+        return await LoadCertificateAsync(path, password, storageFlags, cancellationToken);
     }
 
     public async Task SaveRootCertificateAsync(string pathOrName, string password, X509Certificate2 certificate, CancellationToken cancellationToken)
@@ -31,10 +31,10 @@ internal sealed class CertificateDiskCache : ICertificateCache
         await File.WriteAllBytesAsync(path, exported, cancellationToken);
     }
 
-    public Task<X509Certificate2?> LoadCertificateAsync(string subjectName, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
+    public async Task<X509Certificate2?> LoadCertificateAsync(string subjectName, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
     {
         var filePath = Path.Combine(GetCertificatePath(false), subjectName + DefaultCertificateFileExtension);
-        return Task.FromResult(LoadCertificate(filePath, string.Empty, storageFlags));
+        return await LoadCertificateAsync(filePath, string.Empty, storageFlags, cancellationToken);
     }
 
     public async Task SaveCertificateAsync(string subjectName, X509Certificate2 certificate, CancellationToken cancellationToken)
@@ -118,7 +118,7 @@ internal sealed class CertificateDiskCache : ICertificateCache
         return rootCertificatePath;
     }
 
-    private static X509Certificate2? LoadCertificate(string path, string password, X509KeyStorageFlags storageFlags)
+    private static async Task<X509Certificate2?> LoadCertificateAsync(string path, string password, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
     {
         byte[] exported;
 
@@ -129,7 +129,7 @@ internal sealed class CertificateDiskCache : ICertificateCache
 
         try
         {
-            exported = File.ReadAllBytes(path);
+            exported = await File.ReadAllBytesAsync(path, cancellationToken);
         }
         catch (IOException)
         {

--- a/DevProxy/Proxy/CertificateDiskCache.cs
+++ b/DevProxy/Proxy/CertificateDiskCache.cs
@@ -18,10 +18,10 @@ internal sealed class CertificateDiskCache : ICertificateCache
 
     private string? rootCertificatePath;
 
-    public async Task<X509Certificate2?> LoadRootCertificateAsync(string pathOrName, string password, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
+    public Task<X509Certificate2?> LoadRootCertificateAsync(string pathOrName, string password, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
     {
         var path = GetRootCertificatePath(pathOrName, false);
-        return await LoadCertificateAsync(path, password, storageFlags, cancellationToken);
+        return LoadCertificateAsync(path, password, storageFlags, cancellationToken);
     }
 
     public async Task SaveRootCertificateAsync(string pathOrName, string password, X509Certificate2 certificate, CancellationToken cancellationToken)
@@ -31,10 +31,10 @@ internal sealed class CertificateDiskCache : ICertificateCache
         await File.WriteAllBytesAsync(path, exported, cancellationToken);
     }
 
-    public async Task<X509Certificate2?> LoadCertificateAsync(string subjectName, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
+    public Task<X509Certificate2?> LoadCertificateAsync(string subjectName, X509KeyStorageFlags storageFlags, CancellationToken cancellationToken)
     {
         var filePath = Path.Combine(GetCertificatePath(false), subjectName + DefaultCertificateFileExtension);
-        return await LoadCertificateAsync(filePath, string.Empty, storageFlags, cancellationToken);
+        return LoadCertificateAsync(filePath, string.Empty, storageFlags, cancellationToken);
     }
 
     public async Task SaveCertificateAsync(string subjectName, X509Certificate2 certificate, CancellationToken cancellationToken)

--- a/DevProxy/packages.lock.json
+++ b/DevProxy/packages.lock.json
@@ -35,13 +35,13 @@
       },
       "Microsoft.VisualStudio.Threading": {
         "type": "Direct",
-        "requested": "[17.14.15, )",
-        "resolved": "17.14.15",
-        "contentHash": "1DrCusT3xNLSlaJg77BsUSAzrhjdZBAvvsS0PMzyPM+fGais6SnISOhqdZQop8VVMIBLsYm2gyF9W7THjgavwA==",
+        "requested": "[18.7.23, )",
+        "resolved": "18.7.23",
+        "contentHash": "IiK1otNipjvDIk8SClYwOP1uRZLpVA3luVMKSTPhhjhxqv2pp8/tzfLy/IB7HW+voeEodCTHh0q9LbLIBdGNKA==",
         "dependencies": {
-          "Microsoft.VisualStudio.Threading.Analyzers": "17.14.15",
-          "Microsoft.VisualStudio.Threading.Only": "17.14.15",
-          "Microsoft.VisualStudio.Validation": "17.8.8"
+          "Microsoft.VisualStudio.Threading.Analyzers": "18.7.23",
+          "Microsoft.VisualStudio.Threading.Only": "18.7.23",
+          "Microsoft.VisualStudio.Validation": "17.13.22"
         }
       },
       "Newtonsoft.Json": {
@@ -247,21 +247,21 @@
       },
       "Microsoft.VisualStudio.Threading.Analyzers": {
         "type": "Transitive",
-        "resolved": "17.14.15",
-        "contentHash": "mXQPJsbuUD2ydq4/ffd8h8tSOFCXec+2xJOVNCvXjuMOq/+5EKHq3D2m2MC2+nUaXeFMSt66VS/J4HdKBixgcw=="
+        "resolved": "18.7.23",
+        "contentHash": "dyj6z8m+LFjpeH69hdnciCcRCmD0YgMlvuQEywiEshjqj/blgQ+PuWX8Vd5gkWQFoBN4e+TFxx6DvGNSv/gIKg=="
       },
       "Microsoft.VisualStudio.Threading.Only": {
         "type": "Transitive",
-        "resolved": "17.14.15",
-        "contentHash": "NqONyw1RXyj9P3k5e1uU2k9kc1ptwuU5NJQzG+MPq7vQVHUzBY8HLuJf/N2Rw5H/myD96CVxziDxmjawPuzntw==",
+        "resolved": "18.7.23",
+        "contentHash": "iOaVAQLPt1KxFyYqZqKxqNu8BgQUiPLNeT8XhX+549eWaGw49e1MxjlkjTIBwvlfrU4lPp+Nm99oRpmsgN7RJw==",
         "dependencies": {
-          "Microsoft.VisualStudio.Validation": "17.8.8"
+          "Microsoft.VisualStudio.Validation": "17.13.22"
         }
       },
       "Microsoft.VisualStudio.Validation": {
         "type": "Transitive",
-        "resolved": "17.8.8",
-        "contentHash": "rWXThIpyQd4YIXghNkiv2+VLvzS+MCMKVRDR0GAMlflsdo+YcAN2g2r5U1Ah98OFjQMRexTFtXQQ2LkajxZi3g=="
+        "resolved": "17.13.22",
+        "contentHash": "fC20ITOxlUpGQ0ltAxITQbeFxwuB6OjLT3lByC4+/Gm46o/Mwv9hlIVrBhiUhnqdQzUUvr4EHkdiYe7WOSMLmw=="
       },
       "Newtonsoft.Json.Schema": {
         "type": "Transitive",
@@ -341,8 +341,8 @@
       },
       "YamlDotNet": {
         "type": "Transitive",
-        "resolved": "18.0.0",
-        "contentHash": "ptHVgcYmLejGuWXV7RMFoEqFKYMXnieOlWLPzEslfDtzZ9ngMhjYwykfqjBN2+fMEAEyobozkj07lKEpR4dssA=="
+        "resolved": "18.1.0",
+        "contentHash": "5K+9KFg2TdTl7VXv88Qzi/0lqK6JFoNP3lRuImPYGRV7K/QYklDyTrj4+A+KAki1JsQi6qKY+hDyY7d6WRqjrw=="
       },
       "devproxy.abstractions": {
         "type": "Project",
@@ -355,7 +355,7 @@
           "Scriban": "[7.2.5, )",
           "System.CommandLine": "[2.0.9, )",
           "Unobtanium.Web.Proxy": "[0.1.5, )",
-          "YamlDotNet": "[18.0.0, )"
+          "YamlDotNet": "[18.1.0, )"
         }
       }
     }


### PR DESCRIPTION
Bumps NuGet dependencies:
- **YamlDotNet** from 18.0.0 to 18.1.0
- **Microsoft.VisualStudio.Threading** from 17.14.15 to 18.7.23

The Microsoft.VisualStudio.Threading 18.x update introduced a stricter VSTHRD103 analyzer rule that flagged `CertificateDiskCache.LoadCertificate` for synchronous blocking. Fixed by converting it to an async method using `File.ReadAllBytesAsync`.

This PR consolidates what were previously separate dependabot PRs (#1737, #1745) that couldn't be merged due to branch protection rules requiring approval from someone other than the last pusher.