### PR TITLE
Restore system proxy after a crashed instance

### DIFF
--- a/DevProxy/Commands/StopCommand.cs
+++ b/DevProxy/Commands/StopCommand.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using DevProxy.Proxy;
 using DevProxy.State;
 using System.CommandLine;
 using System.Diagnostics;
@@ -34,18 +35,16 @@ internal sealed class StopCommand : Command
 
         if (pid is not null)
         {
-            var state = await StateManager.LoadStateByPidAsync(pid.Value, cancellationToken);
-            if (state is null)
-            {
-                Console.WriteLine($"No running Dev Proxy instance with PID {pid.Value}.");
-                return 1;
-            }
-
-            return await StopInstanceAsync(state, force, cancellationToken);
+            return await StopByPidAsync(pid.Value, force, cancellationToken);
         }
 
+        // Reconcile any system-proxy registrations left behind by crashed
+        // instances first — this must run before LoadAllStatesAsync, which prunes
+        // (deletes) the stale state files it depends on.
+        var reconciliation = await SystemProxyManager.ReconcileOrphanedSystemProxiesAsync(cancellationToken);
+
         var states = await StateManager.LoadAllStatesAsync(cancellationToken);
-        if (states.Count == 0)
+        if (states.Count == 0 && reconciliation.Orphans.Count == 0)
         {
             Console.WriteLine("Dev Proxy is not running.");
             return 1;
@@ -61,7 +60,53 @@ internal sealed class StopCommand : Command
             }
         }
 
+        ReportReconciledOrphans(reconciliation);
+
         return exitCode;
+    }
+
+    private static async Task<int> StopByPidAsync(int pid, bool force, CancellationToken cancellationToken)
+    {
+        // Capture a potential orphaned system-proxy record before LoadStateByPidAsync
+        // prunes (deletes) the stale state file for a dead PID.
+        var orphan = (await StateManager.GetOrphanedSystemProxyStatesAsync(cancellationToken))
+            .Find(o => o.Pid == pid);
+
+        var state = await StateManager.LoadStateByPidAsync(pid, cancellationToken);
+        if (state is not null)
+        {
+            return await StopInstanceAsync(state, force, cancellationToken);
+        }
+
+        if (orphan is not null)
+        {
+            var liveOwner = await StateManager.FindSystemProxyInstanceAsync(cancellationToken);
+            if (liveOwner is null)
+            {
+                SystemProxyManager.Disable();
+                Console.WriteLine($"Restored system proxy left by crashed Dev Proxy (PID: {pid}).");
+            }
+            else
+            {
+                Console.WriteLine($"Removed stale record for crashed Dev Proxy (PID: {pid}); system proxy is owned by a running instance (PID: {liveOwner.Pid}).");
+            }
+
+            await StateManager.DeleteStateAsync(pid, cancellationToken);
+            return 0;
+        }
+
+        Console.WriteLine($"No running Dev Proxy instance with PID {pid}.");
+        return 1;
+    }
+
+    private static void ReportReconciledOrphans(SystemProxyManager.OrphanReconciliation reconciliation)
+    {
+        foreach (var orphan in reconciliation.Orphans)
+        {
+            Console.WriteLine(reconciliation.SystemProxyDisabled
+                ? $"Restored system proxy left by crashed Dev Proxy (PID: {orphan.Pid})."
+                : $"Removed stale record for crashed Dev Proxy (PID: {orphan.Pid}); system proxy is owned by a running instance.");
+        }
     }
 
     private static async Task<int> StopInstanceAsync(ProxyInstanceState state, bool force, CancellationToken cancellationToken)
@@ -146,7 +191,12 @@ internal sealed class StopCommand : Command
 
     private static async Task<int> ForceStopAsync(ProxyInstanceState state, CancellationToken cancellationToken)
     {
-        DisableSystemProxy();
+        // A killed process can't run its own cleanup, so restore the system proxy
+        // on its behalf before terminating it.
+        if (state.AsSystemProxy)
+        {
+            SystemProxyManager.Disable();
+        }
 
         try
         {
@@ -171,47 +221,5 @@ internal sealed class StopCommand : Command
 
         await StateManager.DeleteStateAsync(state.Pid, cancellationToken);
         return 0;
-    }
-
-    /// <summary>
-    /// Disables the system proxy on macOS by calling toggle-proxy.sh off.
-    /// This ensures the system proxy settings are cleaned up even when the
-    /// daemon process is killed forcefully (SIGKILL cannot be caught).
-    /// </summary>
-    private static void DisableSystemProxy()
-    {
-        if (!OperatingSystem.IsMacOS())
-        {
-            return;
-        }
-
-        var bashScriptPath = Path.Join(AppContext.BaseDirectory, "toggle-proxy.sh");
-        if (!File.Exists(bashScriptPath))
-        {
-            return;
-        }
-
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "/bin/bash",
-            Arguments = $"{bashScriptPath} off",
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        try
-        {
-            using var process = new Process { StartInfo = startInfo };
-            process.Start();
-            if (!process.WaitForExit(TimeSpan.FromSeconds(10)))
-            {
-                process.Kill();
-            }
-        }
-        catch
-        {
-            // Best-effort cleanup — don't block the stop flow
-        }
     }
 }

--- a/DevProxy/Program.cs
+++ b/DevProxy/Program.cs
@@ -51,6 +51,24 @@ static async Task<int> StartDetachedProcessAsync(string[] args)
 {
     var isJsonOutput = IsJsonOutputRequested(args);
 
+    // Recover from a system-proxy registration left behind by a previous
+    // instance that crashed before restoring the OS proxy. This must run before
+    // any state-loading call below, which prunes (deletes) the stale state files
+    // it depends on without restoring the proxy.
+    var reconciliation = await SystemProxyManager.ReconcileOrphanedSystemProxiesAsync();
+    foreach (var orphan in reconciliation.Orphans)
+    {
+        var message = $"Recovered system proxy left by a crashed Dev Proxy instance (PID: {orphan.Pid}).";
+        if (isJsonOutput)
+        {
+            await Console.Out.WriteLineAsync(FormatJsonLogEntry("info", message));
+        }
+        else
+        {
+            await Console.Out.WriteLineAsync(message);
+        }
+    }
+
     // Check if an instance is already running as system proxy
     var systemProxyInstance = await StateManager.FindSystemProxyInstanceAsync();
     if (systemProxyInstance is not null)

--- a/DevProxy/Program.cs
+++ b/DevProxy/Program.cs
@@ -58,7 +58,9 @@ static async Task<int> StartDetachedProcessAsync(string[] args)
     var reconciliation = await SystemProxyManager.ReconcileOrphanedSystemProxiesAsync();
     foreach (var orphan in reconciliation.Orphans)
     {
-        var message = $"Recovered system proxy left by a crashed Dev Proxy instance (PID: {orphan.Pid}).";
+        var message = reconciliation.SystemProxyDisabled
+            ? $"Recovered system proxy left by a crashed Dev Proxy instance (PID: {orphan.Pid})."
+            : $"Removed stale system-proxy registration left by a crashed Dev Proxy instance (PID: {orphan.Pid}) while keeping the current system proxy owner unchanged.";
         if (isJsonOutput)
         {
             await Console.Out.WriteLineAsync(FormatJsonLogEntry("info", message));

--- a/DevProxy/Proxy/ProxyEngine.cs
+++ b/DevProxy/Proxy/ProxyEngine.cs
@@ -159,6 +159,17 @@ sealed class ProxyEngine(
             _logger.LogInformation("Dev Proxy listening on {IPAddress}:{Port}...", endPoint.IpAddress, endPoint.Port);
         }
 
+        // Recover from a system-proxy registration left behind by a previous
+        // instance that crashed before restoring the OS proxy, so a stale
+        // registration doesn't linger across runs.
+        var reconciliation = await SystemProxyManager.ReconcileOrphanedSystemProxiesAsync(stoppingToken);
+        foreach (var orphan in reconciliation.Orphans)
+        {
+            _logger.LogInformation(
+                "Recovered system proxy left by a crashed Dev Proxy instance (PID: {Pid}).",
+                orphan.Pid);
+        }
+
         if (_config.AsSystemProxy)
         {
             if (RunTime.IsWindows)

--- a/DevProxy/Proxy/ProxyEngine.cs
+++ b/DevProxy/Proxy/ProxyEngine.cs
@@ -165,9 +165,18 @@ sealed class ProxyEngine(
         var reconciliation = await SystemProxyManager.ReconcileOrphanedSystemProxiesAsync(stoppingToken);
         foreach (var orphan in reconciliation.Orphans)
         {
-            _logger.LogInformation(
-                "Recovered system proxy left by a crashed Dev Proxy instance (PID: {Pid}).",
-                orphan.Pid);
+            if (reconciliation.SystemProxyDisabled)
+            {
+                _logger.LogInformation(
+                    "Recovered system proxy left by a crashed Dev Proxy instance (PID: {Pid}).",
+                    orphan.Pid);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Removed stale system-proxy registration left by a crashed Dev Proxy instance (PID: {Pid}) while keeping the current system proxy owner unchanged.",
+                    orphan.Pid);
+            }
         }
 
         if (_config.AsSystemProxy)

--- a/DevProxy/Proxy/SystemProxyManager.cs
+++ b/DevProxy/Proxy/SystemProxyManager.cs
@@ -109,11 +109,12 @@ internal static class SystemProxyManager
         var startInfo = new ProcessStartInfo
         {
             FileName = "/bin/bash",
-            Arguments = $"{bashScriptPath} off",
             RedirectStandardOutput = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
+        startInfo.ArgumentList.Add(bashScriptPath);
+        startInfo.ArgumentList.Add("off");
 
         using var process = new Process { StartInfo = startInfo };
         _ = process.Start();

--- a/DevProxy/Proxy/SystemProxyManager.cs
+++ b/DevProxy/Proxy/SystemProxyManager.cs
@@ -1,0 +1,125 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using DevProxy.Abstractions.Utils;
+using DevProxy.State;
+using System.Diagnostics;
+using Titanium.Web.Proxy;
+
+namespace DevProxy.Proxy;
+
+/// <summary>
+/// Restores the operating system proxy settings out-of-process.
+/// Used to recover from a Dev Proxy instance that registered itself as the
+/// system proxy but was terminated without running its normal cleanup (crash,
+/// SIGKILL, OOM, power loss). The operation is best-effort, idempotent, and
+/// safe to call even when no system proxy is currently configured.
+/// </summary>
+internal static class SystemProxyManager
+{
+    /// <summary>
+    /// The outcome of reconciling orphaned system-proxy registrations.
+    /// </summary>
+    /// <param name="Orphans">The orphaned instance records that were reconciled.</param>
+    /// <param name="SystemProxyDisabled">
+    /// True if the OS system proxy was disabled as part of reconciliation. This
+    /// is false when a live instance still owns the system proxy, in which case
+    /// only the stale state records are removed.
+    /// </param>
+    internal readonly record struct OrphanReconciliation(
+        IReadOnlyList<ProxyInstanceState> Orphans,
+        bool SystemProxyDisabled);
+
+    /// <summary>
+    /// Disables the operating system proxy.
+    /// On Windows this clears the WinINET system proxy settings; on macOS it
+    /// runs <c>toggle-proxy.sh off</c>. On Linux this is a no-op because Dev
+    /// Proxy never configures a system proxy there.
+    /// </summary>
+    public static void Disable()
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                DisableWindows();
+            }
+            else if (OperatingSystem.IsMacOS())
+            {
+                DisableMacOS();
+            }
+            // Linux: Dev Proxy never sets a system proxy, so there's nothing to restore.
+        }
+        catch
+        {
+            // Best-effort cleanup — never block the stop flow.
+        }
+    }
+
+    /// <summary>
+    /// Reconciles system-proxy registrations left behind by crashed instances.
+    /// Restores the OS proxy (unless a live instance still owns it) and removes
+    /// the stale state records. Safe to call when there are no orphans.
+    /// </summary>
+    public static async Task<OrphanReconciliation> ReconcileOrphanedSystemProxiesAsync(CancellationToken cancellationToken = default)
+    {
+        // Capture orphans before any liveness-pruning call deletes their state files.
+        var orphans = await StateManager.GetOrphanedSystemProxyStatesAsync(cancellationToken);
+        if (orphans.Count == 0)
+        {
+            return new([], false);
+        }
+
+        // Only touch the global OS proxy setting if no live instance currently
+        // owns it — otherwise we'd disable a proxy a running instance depends on.
+        var liveOwner = await StateManager.FindSystemProxyInstanceAsync(cancellationToken);
+        var disabled = false;
+        if (liveOwner is null)
+        {
+            Disable();
+            disabled = true;
+        }
+
+        foreach (var orphan in orphans)
+        {
+            await StateManager.DeleteStateAsync(orphan.Pid, cancellationToken);
+        }
+
+        return new(orphans, disabled);
+    }
+
+    private static void DisableWindows()
+    {
+        // DisableAllSystemProxies clears the WinINET proxy settings directly and
+        // does not require a running proxy, so a fresh instance is enough to undo
+        // a registration left behind by a crashed process.
+        using var proxyServer = new ProxyServer(userTrustRootCertificate: false);
+        proxyServer.DisableAllSystemProxies();
+    }
+
+    private static void DisableMacOS()
+    {
+        var bashScriptPath = Path.Join(ProxyUtils.AppFolder ?? AppContext.BaseDirectory, "toggle-proxy.sh");
+        if (!File.Exists(bashScriptPath))
+        {
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "/bin/bash",
+            Arguments = $"{bashScriptPath} off",
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var process = new Process { StartInfo = startInfo };
+        _ = process.Start();
+        if (!process.WaitForExit(TimeSpan.FromSeconds(10)))
+        {
+            process.Kill();
+        }
+    }
+}

--- a/DevProxy/State/StateManager.cs
+++ b/DevProxy/State/StateManager.cs
@@ -176,6 +176,46 @@ internal static class StateManager
     }
 
     /// <summary>
+    /// Finds state records left behind by instances that registered as the
+    /// system proxy but whose process is no longer alive (e.g. crashed or killed
+    /// before running cleanup). These represent orphaned system-proxy
+    /// registrations that outlived the process and should be reconciled by
+    /// restoring the OS proxy.
+    /// The state files are left in place so the caller can remove them (via
+    /// <see cref="DeleteStateAsync(int, CancellationToken)"/>) only after the
+    /// system proxy has been restored.
+    /// </summary>
+    public static async Task<List<ProxyInstanceState>> GetOrphanedSystemProxyStatesAsync(CancellationToken cancellationToken = default)
+    {
+        var configFolder = GetConfigFolder();
+        if (!Directory.Exists(configFolder))
+        {
+            return [];
+        }
+
+        var orphaned = new List<ProxyInstanceState>();
+        var seenPids = new HashSet<int>();
+
+        var stateFiles = Directory.GetFiles(configFolder, $"{StateFilePrefix}*{StateFileExtension}");
+        var legacyPath = GetStateFilePath();
+        var paths = File.Exists(legacyPath) ? [.. stateFiles, legacyPath] : stateFiles;
+
+        foreach (var filePath in paths)
+        {
+            var state = await ReadStateFromFileAsync(filePath, cancellationToken);
+            if (state is not null &&
+                state.AsSystemProxy &&
+                !IsProcessRunning(state.Pid) &&
+                seenPids.Add(state.Pid))
+            {
+                orphaned.Add(state);
+            }
+        }
+
+        return orphaned;
+    }
+
+    /// <summary>
     /// Deletes the state file for a specific PID.
     /// Also cleans up the legacy state file if it belongs to this PID.
     /// </summary>
@@ -256,6 +296,33 @@ internal static class StateManager
         string filePath,
         CancellationToken cancellationToken)
     {
+        var state = await ReadStateFromFileAsync(filePath, cancellationToken);
+        if (state is null)
+        {
+            return null;
+        }
+
+        // Verify the process is still running
+        if (!IsProcessRunning(state.Pid))
+        {
+            // Clean up stale state file
+            DeleteFile(filePath);
+            return null;
+        }
+
+        return state;
+    }
+
+    /// <summary>
+    /// Reads and deserializes a state file without verifying process liveness or
+    /// pruning stale files. Returns null if the file doesn't exist or can't be
+    /// parsed. Use this when the caller needs to inspect records of processes that
+    /// may no longer be alive (e.g. crash recovery).
+    /// </summary>
+    private static async Task<ProxyInstanceState?> ReadStateFromFileAsync(
+        string filePath,
+        CancellationToken cancellationToken)
+    {
         if (!File.Exists(filePath))
         {
             return null;
@@ -264,22 +331,7 @@ internal static class StateManager
         try
         {
             var json = await File.ReadAllTextAsync(filePath, cancellationToken);
-            var state = JsonSerializer.Deserialize<ProxyInstanceState>(json);
-
-            if (state is null)
-            {
-                return null;
-            }
-
-            // Verify the process is still running
-            if (!IsProcessRunning(state.Pid))
-            {
-                // Clean up stale state file
-                DeleteFile(filePath);
-                return null;
-            }
-
-            return state;
+            return JsonSerializer.Deserialize<ProxyInstanceState>(json);
         }
         catch (JsonException)
         {


### PR DESCRIPTION
## Summary

When a detached Dev Proxy instance running with `--as-system-proxy true` is terminated **uncleanly** (crash, `kill -9`, OOM, power loss), the OS proxy is left pointing at the now-dead port and `devproxy stop --force` could not recover it — it printed `Dev Proxy is not running.` and exited 1, leaving the machine without working network access.

**Root cause:** `StateManager` prunes any state file whose PID is no longer alive *before* the stop command reads it, so a crashed instance's record is already gone by the time `stop --force` runs ⇒ no instance is found ⇒ `SystemProxyManager.Disable()` is never invoked. `--force` therefore only worked for a *hung-but-alive* instance, not the *dead* one it's meant to recover.

The fix decouples "restore the OS proxy" from "find a live instance."

Fixes #1731.

## Changes

- **`SystemProxyManager.cs` (new)** — cross-platform, idempotent `Disable()` (Windows WinINET via `ProxyServer.DisableAllSystemProxies()`, macOS `toggle-proxy.sh off`, Linux no-op) plus `ReconcileOrphanedSystemProxiesAsync()`. Reconciliation is **guarded**: the global OS proxy is only disabled when no live instance still owns it — otherwise only the stale record is removed.
- **`StateManager.cs`** — added `GetOrphanedSystemProxyStatesAsync()` which reads records for dead PIDs with `asSystemProxy: true` **without** pruning them first, and extracted a non-pruning `ReadStateFromFileAsync` helper.
- **`StopCommand.cs`** — `devproxy stop` and `devproxy stop --pid` now reconcile crashed system-proxy orphans (restore the OS proxy + clean up the record) in addition to stopping live instances. Gated on Dev Proxy's own `asSystemProxy` record, so a proxy Dev Proxy didn't set is never touched.
- **`Program.cs` / `ProxyEngine.cs`** — startup self-heal so a stale registration is recovered on the next run. The reconciliation runs at the very top of the detached launcher (before its state-loading port-conflict check, which would otherwise prune the orphan without restoring the proxy) and in `ProxyEngine` for foreground runs.

## Safety

- Disabling the system proxy is idempotent and cross-platform, so restoring it is low-risk.
- Reconciliation only ever acts on a stale state record that Dev Proxy itself wrote with `asSystemProxy: true` — it never disables a corporate/third-party proxy.
- The global OS proxy is only disabled when no live instance currently owns it.

## Testing (macOS)

Verified with the built binary (system proxy was off, so `Disable()` was a safe no-op):

- Crashed system-proxy orphan → `stop` restores it, deletes the record, exit 0
- Nothing running → `Dev Proxy is not running.`, exit 1
- Non-system-proxy dead orphan → **not** treated as a restore
- `stop --pid` on a crashed orphan → restored
- Live instance + orphan present → graceful stop **and** orphan reconcile both succeed
- Detached startup self-heal → `Recovered system proxy left by a crashed Dev Proxy instance` logged, orphan cleaned up

Full solution builds clean (0 warnings, 0 errors).

## Notes

- The Windows WinINET disable path compiles but was not exercised at runtime (tested on macOS) — worth a quick manual check on Windows before release.
- The detached-instance model keys liveness on PID alone, which is vulnerable to PID reuse. That pre-existing caveat is intentionally out of scope here and tracked in #1755.
