### PR TITLE
Bump Microsoft.OpenApi from 3.7.0 to 3.8.0

### DIFF
--- a/DevProxy.Abstractions/DevProxy.Abstractions.csproj
+++ b/DevProxy.Abstractions/DevProxy.Abstractions.csproj
@@ -39,8 +39,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.OpenApi" Version="3.7.0" />
-    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.7.0" />
+    <PackageReference Include="Microsoft.OpenApi" Version="3.8.0" />
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.8.0" />
     <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="Scriban" Version="7.2.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.9" />

--- a/DevProxy.Abstractions/packages.lock.json
+++ b/DevProxy.Abstractions/packages.lock.json
@@ -72,17 +72,17 @@
       },
       "Microsoft.OpenApi": {
         "type": "Direct",
-        "requested": "[3.7.0, )",
-        "resolved": "3.7.0",
-        "contentHash": "7Ld/wUsxSEKBjAk8nPZ13qkju5kNoh20gf0JHPeHrK41tMZRpIq9amXFAOHncicjg0U5M035I+6/z3cBsYBHfg=="
+        "requested": "[3.8.0, )",
+        "resolved": "3.8.0",
+        "contentHash": "bF+KnfJSd9KLUOZxl07IdhmQcvz/adqU+GVub7+SVOydHpJGOGIWqwngZ3JxgtDpKYRA6vlk+0tv82G0KXRuhw=="
       },
       "Microsoft.OpenApi.YamlReader": {
         "type": "Direct",
-        "requested": "[3.7.0, )",
-        "resolved": "3.7.0",
-        "contentHash": "+KSHfoEiXDFmCeIG6T5xAuYNFulwfxxBh4AJOY6dvGrDeFVV4eL4/xP/RNEaFYvcSZpLkj3ZoQ8Vn3vtUViu5g==",
+        "requested": "[3.8.0, )",
+        "resolved": "3.8.0",
+        "contentHash": "1mMfB9LsIsYvfcmc0KIhAswzcy58nZDFJnVoV2Cxat4Ij6vOxW1MsMjROpyeDmAE3ueE6vKg7/BZ5uafrd23jw==",
         "dependencies": {
-          "Microsoft.OpenApi": "3.7.0",
+          "Microsoft.OpenApi": "3.8.0",
           "SharpYaml": "2.1.4"
         }
       },

--- a/DevProxy.Plugins/DevProxy.Plugins.csproj
+++ b/DevProxy.Plugins/DevProxy.Plugins.csproj
@@ -37,11 +37,11 @@
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OpenApi" Version="3.7.0">
+    <PackageReference Include="Microsoft.OpenApi" Version="3.8.0">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.7.0">
+    <PackageReference Include="Microsoft.OpenApi.YamlReader" Version="3.8.0">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/DevProxy.Plugins/packages.lock.json
+++ b/DevProxy.Plugins/packages.lock.json
@@ -54,17 +54,17 @@
       },
       "Microsoft.OpenApi": {
         "type": "Direct",
-        "requested": "[3.7.0, )",
-        "resolved": "3.7.0",
-        "contentHash": "7Ld/wUsxSEKBjAk8nPZ13qkju5kNoh20gf0JHPeHrK41tMZRpIq9amXFAOHncicjg0U5M035I+6/z3cBsYBHfg=="
+        "requested": "[3.8.0, )",
+        "resolved": "3.8.0",
+        "contentHash": "bF+KnfJSd9KLUOZxl07IdhmQcvz/adqU+GVub7+SVOydHpJGOGIWqwngZ3JxgtDpKYRA6vlk+0tv82G0KXRuhw=="
       },
       "Microsoft.OpenApi.YamlReader": {
         "type": "Direct",
-        "requested": "[3.7.0, )",
-        "resolved": "3.7.0",
-        "contentHash": "+KSHfoEiXDFmCeIG6T5xAuYNFulwfxxBh4AJOY6dvGrDeFVV4eL4/xP/RNEaFYvcSZpLkj3ZoQ8Vn3vtUViu5g==",
+        "requested": "[3.8.0, )",
+        "resolved": "3.8.0",
+        "contentHash": "1mMfB9LsIsYvfcmc0KIhAswzcy58nZDFJnVoV2Cxat4Ij6vOxW1MsMjROpyeDmAE3ueE6vKg7/BZ5uafrd23jw==",
         "dependencies": {
-          "Microsoft.OpenApi": "3.7.0",
+          "Microsoft.OpenApi": "3.8.0",
           "SharpYaml": "2.1.4"
         }
       },
@@ -535,8 +535,8 @@
           "Microsoft.Extensions.Configuration.Json": "[10.0.9, )",
           "Microsoft.Extensions.FileSystemGlobbing": "[10.0.9, )",
           "Microsoft.Extensions.Logging.Abstractions": "[10.0.9, )",
-          "Microsoft.OpenApi": "[3.7.0, )",
-          "Microsoft.OpenApi.YamlReader": "[3.7.0, )",
+          "Microsoft.OpenApi": "[3.8.0, )",
+          "Microsoft.OpenApi.YamlReader": "[3.8.0, )",
           "Newtonsoft.Json.Schema": "[4.0.1, )",
           "Scriban": "[7.2.5, )",
           "System.CommandLine": "[2.0.9, )",

--- a/DevProxy/packages.lock.json
+++ b/DevProxy/packages.lock.json
@@ -233,15 +233,15 @@
       },
       "Microsoft.OpenApi": {
         "type": "Transitive",
-        "resolved": "3.7.0",
-        "contentHash": "7Ld/wUsxSEKBjAk8nPZ13qkju5kNoh20gf0JHPeHrK41tMZRpIq9amXFAOHncicjg0U5M035I+6/z3cBsYBHfg=="
+        "resolved": "3.8.0",
+        "contentHash": "bF+KnfJSd9KLUOZxl07IdhmQcvz/adqU+GVub7+SVOydHpJGOGIWqwngZ3JxgtDpKYRA6vlk+0tv82G0KXRuhw=="
       },
       "Microsoft.OpenApi.YamlReader": {
         "type": "Transitive",
-        "resolved": "3.7.0",
-        "contentHash": "+KSHfoEiXDFmCeIG6T5xAuYNFulwfxxBh4AJOY6dvGrDeFVV4eL4/xP/RNEaFYvcSZpLkj3ZoQ8Vn3vtUViu5g==",
+        "resolved": "3.8.0",
+        "contentHash": "1mMfB9LsIsYvfcmc0KIhAswzcy58nZDFJnVoV2Cxat4Ij6vOxW1MsMjROpyeDmAE3ueE6vKg7/BZ5uafrd23jw==",
         "dependencies": {
-          "Microsoft.OpenApi": "3.7.0",
+          "Microsoft.OpenApi": "3.8.0",
           "SharpYaml": "2.1.4"
         }
       },
@@ -349,8 +349,8 @@
         "dependencies": {
           "Markdig": "[1.3.2, )",
           "Microsoft.EntityFrameworkCore.Sqlite": "[10.0.9, )",
-          "Microsoft.OpenApi": "[3.7.0, )",
-          "Microsoft.OpenApi.YamlReader": "[3.7.0, )",
+          "Microsoft.OpenApi": "[3.8.0, )",
+          "Microsoft.OpenApi.YamlReader": "[3.8.0, )",
           "Newtonsoft.Json.Schema": "[4.0.1, )",
           "Scriban": "[7.2.5, )",
           "System.CommandLine": "[2.0.9, )",


### PR DESCRIPTION
Bumps [Microsoft.OpenApi](https://github.com/Microsoft/OpenAPI.NET) and Microsoft.OpenApi.YamlReader from 3.7.0 to 3.8.0 in DevProxy.Abstractions and DevProxy.Plugins.

Replaces #1762 (which was closed because dependabot couldn't rebase it after it was edited by a non-dependabot user).