### PR TITLE
Fix mismatched CodeQL action versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -81,4 +81,4 @@ jobs:
       run: dotnet build --no-restore -c Release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+      uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8


### PR DESCRIPTION
## Summary

- update the CodeQL analyze step to v4.37.8
- keep the init and analyze steps pinned to the same commit
- prevent configuration version mismatch failures during analysis and cleanup

Fixes the workflow regression introduced by #1834.