### PR TITLE
Use local templates for config new

### DIFF
--- a/.github/skills/upgrade-devproxy-version/SKILL.md
+++ b/.github/skills/upgrade-devproxy-version/SKILL.md
@@ -56,6 +56,8 @@ Update `schemas/v<old>/` to `schemas/v<new>/` in:
 - `DevProxy/config/microsoft-graph.json` - all `$schema` URLs
 - `DevProxy/config/microsoft-graph-rate-limiting.json` - `$schema` URL
 - `DevProxy/config/spo-csom-types.json` - `$schema` URL
+- `DevProxy/config-templates/devproxyrc.json` - `$schema` URL
+- `DevProxy/config-templates/devproxyrc.yaml` - `$schema` URL
 - `DevProxy.Plugins/Mocking/MockResponsePlugin.cs` - hardcoded schema URL
 
 **Category C: Installer Files** (format: `X.Y.Z` or `X.Y.Z-beta.N`)

--- a/.github/skills/upgrade-devproxy-version/scripts/upgrade-version.sh
+++ b/.github/skills/upgrade-devproxy-version/scripts/upgrade-version.sh
@@ -56,10 +56,17 @@ done
 echo ""
 echo "Step 3: Updating schema URLs..."
 # JSON files
-for json in DevProxy/devproxyrc.json DevProxy/devproxy-errors.json DevProxy/config/*.json; do
+for json in DevProxy/devproxyrc.json DevProxy/devproxy-errors.json DevProxy/config/*.json DevProxy/config-templates/*.json; do
     if [[ -f "$WORKSPACE_ROOT/$json" ]]; then
         sed -i '' "s|schemas/v$CURRENT_VERSION/|schemas/v$NEW_VERSION/|g" "$WORKSPACE_ROOT/$json"
         echo "  Updated: $json"
+    fi
+done
+
+for yaml in DevProxy/config-templates/*.yaml; do
+    if [[ -f "$WORKSPACE_ROOT/$yaml" ]]; then
+        sed -i '' "s|schemas/v$CURRENT_VERSION/|schemas/v$NEW_VERSION/|g" "$WORKSPACE_ROOT/$yaml"
+        echo "  Updated: $yaml"
     fi
 done
 

--- a/DevProxy/Commands/ConfigCommand.cs
+++ b/DevProxy/Commands/ConfigCommand.cs
@@ -36,13 +36,6 @@ sealed class GitHubTreeItem
     public string Type { get; set; } = string.Empty;
 }
 
-sealed class VisualStudioCodeSnippet
-{
-    public string? Prefix { get; set; }
-    public string[]? Body { get; set; }
-    public string? Description { get; set; }
-}
-
 sealed class ConfigCommand : Command
 {
     private enum ConfigFileFormat
@@ -54,8 +47,8 @@ sealed class ConfigCommand : Command
     private readonly ILogger _logger;
     private readonly IProxyConfiguration _proxyConfiguration;
     private readonly HttpClient _httpClient;
-    private readonly string snippetsBaseUrl = $"https://aka.ms/devproxy/snippets/v{ProxyUtils.NormalizeVersion(ProxyUtils.ProductVersion)}";
-    private readonly string configFileSnippetName = "ConfigFile";
+    private const string ConfigTemplatesFolder = "config-templates";
+
     public ConfigCommand(
         HttpClient httpClient,
         IProxyConfiguration proxyConfiguration,
@@ -447,35 +440,13 @@ sealed class ConfigCommand : Command
         try
         {
             var selectedFormat = format ?? GetConfigFileFormatFromFileName(name);
-
-            var snippets = await DownloadSnippetsAsync(selectedFormat);
-            if (snippets is null)
-            {
-                return;
-            }
-
-            if (!snippets.TryGetValue(configFileSnippetName, out var snippet))
-            {
-                if (outputFormat == OutputFormat.Text)
-                {
-                    _logger.LogError("Snippet {SnippetName} not found", configFileSnippetName);
-                }
-                return;
-            }
-
-            if (snippet.Body is null || snippet.Body.Length == 0)
-            {
-                if (outputFormat == OutputFormat.Text)
-                {
-                    _logger.LogError("Snippet {SnippetName} is empty", configFileSnippetName);
-                }
-                return;
-            }
-
-            var snippetBody = GetSnippetBody(snippet.Body);
+            var templateFileName = selectedFormat == ConfigFileFormat.Yaml ? "devproxyrc.yaml" : "devproxyrc.json";
+            var templateFilePath = Path.Combine(AppContext.BaseDirectory, ConfigTemplatesFolder, templateFileName);
+            _logger.LogDebug("Reading config template from {TemplateFilePath}...", templateFilePath);
+            var template = await File.ReadAllTextAsync(templateFilePath);
 
             var targetFileName = GetTargetFileName(name);
-            await File.WriteAllTextAsync(targetFileName, snippetBody);
+            await File.WriteAllTextAsync(targetFileName, template);
 
             if (outputFormat == OutputFormat.Json)
             {
@@ -494,7 +465,7 @@ sealed class ConfigCommand : Command
         {
             if (outputFormat == OutputFormat.Text)
             {
-                _logger.LogError(ex, "Error downloading config");
+                _logger.LogError(ex, "Error creating config");
             }
         }
     }
@@ -506,32 +477,6 @@ sealed class ConfigCommand : Command
     {
         var extension = Path.GetExtension(name).ToLowerInvariant();
         return extension is ".yaml" or ".yml" ? ConfigFileFormat.Yaml : ConfigFileFormat.Json;
-    }
-
-    private async Task<Dictionary<string, VisualStudioCodeSnippet>?> DownloadSnippetsAsync(ConfigFileFormat format)
-    {
-        var formatSuffix = format == ConfigFileFormat.Yaml ? "yaml" : "json";
-        var snippetsFileUrl = $"{snippetsBaseUrl}/{formatSuffix}";
-        _logger.LogDebug("Downloading snippets from {SnippetsFileUrl}...", snippetsFileUrl);
-        var response = await _httpClient.GetAsync(new Uri(snippetsFileUrl));
-        if (response.IsSuccessStatusCode)
-        {
-            var content = await response.Content.ReadAsStringAsync();
-            try
-            {
-                return JsonSerializer.Deserialize<Dictionary<string, VisualStudioCodeSnippet>>(content, ProxyUtils.JsonSerializerOptions);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex, "Failed to parse snippets from {Url}", snippetsFileUrl);
-                return null;
-            }
-        }
-        else
-        {
-            _logger.LogError("Failed to download snippets. Status code: {StatusCode}", response.StatusCode);
-            return null;
-        }
     }
 
     private string GetTargetFileName(string name)
@@ -564,16 +509,6 @@ sealed class ConfigCommand : Command
         }
 
         return newFolder;
-    }
-
-    private static string? GetSnippetBody(string[] bodyLines)
-    {
-        var body = string.Join("\n", bodyLines);
-        // unescape $
-        body = body.Replace("\\$", "$", StringComparison.OrdinalIgnoreCase);
-        // remove snippet $n markers
-        body = Regex.Replace(body, @"\$[0-9]+", "");
-        return body;
     }
 
     private static string? ResolveConfigFile(string? configFilePath)

--- a/DevProxy/DevProxy.csproj
+++ b/DevProxy/DevProxy.csproj
@@ -89,6 +89,9 @@
     <None Update="config\spo-csom-types.jpg">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="config-templates\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="prompts\*.prompty">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/DevProxy/config-templates/devproxyrc.json
+++ b/DevProxy/config-templates/devproxyrc.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.2.0/rc.schema.json",
+  "plugins": [
+  ],
+  "urlsToWatch": [
+  ],
+  "logLevel": "information",
+  "newVersionNotification": "stable",
+  "showSkipMessages": true
+}

--- a/DevProxy/config-templates/devproxyrc.yaml
+++ b/DevProxy/config-templates/devproxyrc.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/dotnet/dev-proxy/main/schemas/v3.2.0/rc.schema.json
+plugins:
+  -
+urlsToWatch:
+  -
+logLevel: information
+newVersionNotification: stable
+showSkipMessages: true


### PR DESCRIPTION
## Summary

- store the minimal JSON and YAML templates required by `config new` in this repository
- create new configuration files from packaged templates instead of downloading the full Toolkit snippet catalogs
- include the templates in build, publish, and installer outputs
- update the version-upgrade automation to maintain template schema URLs

## Validation

- `dotnet build DevProxy/DevProxy.csproj`
- `dotnet build DevProxy.Plugins/DevProxy.Plugins.csproj`
- generated and validated JSON and YAML files with `config new`
- verified both templates are present in single-file publish output